### PR TITLE
Normalize current page slug detection for SEO metadata

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -14,7 +14,7 @@ import CalculatorIndex from '../components/general/CalculatorIndex';
 // Define a mapping for page names to titles and descriptions for SEO
 // This object will be used to programmatically set SEO meta tags for each page.
 // In a larger application, this data might come from a CMS or a more complex routing configuration.
-const pageSeo = {
+export const pageSeo = {
   Home: {
     title: 'UK Salary, Tax & Mortgage Calculators | Calculate My Money',
     description:


### PR DESCRIPTION
## Summary
- export the shared `pageSeo` map so router utilities can reuse the SEO definitions
- normalize router slug detection with `createPageUrl`, calculator config data, and SEO keys to resolve the right page metadata
- fall back through slug candidates so calculator hubs and legacy slugs update document metadata correctly

## Testing
- npm run build *(fails: RequestError ECONNREFUSED while generating critical CSS in this environment)*
- Manual Playwright check of /privacy-policy, /salary-calculator-uk, /mortgage-calculator

------
https://chatgpt.com/codex/tasks/task_e_68debbc9173c832094c92a6329ccf3de