### PR TITLE
Fix salary and cost-of-living links to use slugs and query params

### DIFF
--- a/src/pages/CostOfLiving.jsx
+++ b/src/pages/CostOfLiving.jsx
@@ -7,6 +7,7 @@ import { MapPin, Users, TrendingUp } from 'lucide-react';
 
 export default function CostOfLiving() {
   const regions = [...new Set(ukCities.map((city) => city.region))];
+  const costOfLivingPageBase = createPageUrl('CostOfLivingPage');
 
   return (
     <div className="bg-white dark:bg-gray-900">
@@ -33,7 +34,7 @@ export default function CostOfLiving() {
                 .filter((city) => city.region === region)
                 .map((city) => (
                   <Link
-                    to={createPageUrl(`CostOfLivingPage?slug=${createSlug(city.name)}`)}
+                    to={`${costOfLivingPageBase}?slug=${createSlug(city.name)}`}
                     key={city.name}
                     className="group"
                   >

--- a/src/pages/CostOfLivingPage.jsx
+++ b/src/pages/CostOfLivingPage.jsx
@@ -28,6 +28,7 @@ const costOfLivingFAQs = [
 
 export default function CostOfLivingPage() {
   const location = useLocation();
+  const costOfLivingPageBase = createPageUrl('CostOfLivingPage');
   const city = useMemo(() => {
     const urlParams = new URLSearchParams(location.search);
     const slug = urlParams.get('slug');
@@ -140,7 +141,7 @@ export default function CostOfLivingPage() {
                 {relatedCities.length > 0 ? (
                   relatedCities.map((relatedCity) => (
                     <Link
-                      to={createPageUrl(`CostOfLivingPage?slug=${createSlug(relatedCity.name)}`)}
+                      to={`${costOfLivingPageBase}?slug=${createSlug(relatedCity.name)}`}
                       key={relatedCity.name}
                       className="block p-3 bg-white border rounded-lg hover:bg-gray-100 transition-colors"
                     >

--- a/src/pages/JobSalaries.jsx
+++ b/src/pages/JobSalaries.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { createPageUrl } from '@/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
@@ -51,7 +50,7 @@ export default function JobSalaries() {
             {filteredJobs.length > 0 ? (
               filteredJobs.map((job) => (
                 <Link
-                  to={createPageUrl(`JobSalaryPage?slug=${createSlug(job.title)}`)}
+                  to={`/job-salaries/${createSlug(job.title)}`}
                   key={job.title}
                   className="group"
                 >
@@ -91,7 +90,7 @@ export default function JobSalaries() {
                   .filter((job) => job.category === category)
                   .map((job) => (
                     <Link
-                      to={createPageUrl(`JobSalaryPage?slug=${createSlug(job.title)}`)}
+                      to={`/job-salaries/${createSlug(job.title)}`}
                       key={job.title}
                       className="group"
                     >

--- a/src/pages/Sitemap.jsx
+++ b/src/pages/Sitemap.jsx
@@ -70,12 +70,13 @@ export default function Sitemap() {
     .sort((a, b) => a.title.localeCompare(b.title));
 
   const jobLinks = jobTitles.map((job) => ({
-    url: createPageUrl(`JobSalaryPage?slug=${createSlug(job.title)}`),
+    url: `/job-salaries/${createSlug(job.title)}`,
     title: `${job.title} Salary`,
   }));
 
+  const costOfLivingPageBase = createPageUrl('CostOfLivingPage');
   const cityLinks = ukCities.map((city) => ({
-    url: createPageUrl(`CostOfLivingPage?slug=${createSlug(city.name)}`),
+    url: `${costOfLivingPageBase}?slug=${createSlug(city.name)}`,
     title: `Cost of Living in ${city.name}`,
   }));
 


### PR DESCRIPTION
## Summary
- update job salary cards and sitemap entries to link directly to the /job-salaries/<slug> route
- preserve ?slug query strings for cost-of-living navigation and sitemap links
- keep related city links consistent on the cost-of-living detail page

## Testing
- npm run build *(fails: critical CSS generation attempts to fetch http://localhost/ and is refused in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68debc72cbe08320bf8b73003a1aa0bb