### PR TITLE
Fix createPageUrl slug generation

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,13 @@
 export function createPageUrl(pageName: string) {
-  return '/' + pageName.toLowerCase().replace(/ /g, '-');
+  return (
+    '/' +
+    pageName
+      // Insert hyphens before uppercase characters that follow lowercase or numbers
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      // Handle sequences of uppercase letters before a lowercase letter
+      .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+      // Replace any remaining spaces with hyphens
+      .replace(/\s+/g, '-')
+      .toLowerCase()
+  );
 }


### PR DESCRIPTION
## Summary
- update `createPageUrl` to insert hyphens before uppercase letters and spaces before lowercasing
- ensure PascalCase identifiers now become hyphenated slugs compatible with existing links

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `node -e "import { createPageUrl } from './src/utils/index.ts'; console.log(createPageUrl('CostOfLivingPage'))"`


------
https://chatgpt.com/codex/tasks/task_e_68deede4809483208c7510fcd2cd7987