### PR TITLE
Add legacy jobsalarypage route mapping

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -430,6 +430,7 @@ function PagesContent() {
           <Route path="/blog-debt-repayment-strategies" element={<BlogDebtRepaymentStrategies />} />
           <Route path="/blog-financial-psychology" element={<BlogFinancialPsychology />} />
           <Route path="/job-salary-page" element={<JobSalaryPage />} />
+          <Route path="/jobsalarypage" element={<JobSalaryPage />} />
           <Route path="/cost-of-living-page" element={<CostOfLivingPage />} />
           <Route path="/uk-financial-stats" element={<UKFinancialStats />} />
           <Route path="/methodology" element={<Methodology />} />


### PR DESCRIPTION
## Summary
- add a legacy `/jobsalarypage` route to reuse the existing JobSalaryPage component

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e014245a708320b7c38a41a47e6526