### PR TITLE
Use slug routes for cost of living pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Disallow: /*?q=
-Disallow: /*?slug=
 Sitemap: https://www.calcmymoney.co.uk/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -568,7 +568,7 @@
 
   <!-- Education & reference pages -->
   <url>
-    <loc>https://www.calcmymoney.co.uk/cost-of-living-page</loc>
+    <loc>https://www.calcmymoney.co.uk/cost-of-living</loc>
     <lastmod>2025-10-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/src/pages/CostOfLiving.jsx
+++ b/src/pages/CostOfLiving.jsx
@@ -7,7 +7,7 @@ import { MapPin, Users, TrendingUp } from 'lucide-react';
 
 export default function CostOfLiving() {
   const regions = [...new Set(ukCities.map((city) => city.region))];
-  const costOfLivingPageBase = createPageUrl('CostOfLivingPage');
+  const costOfLivingBase = createPageUrl('CostOfLiving');
 
   return (
     <div className="bg-white dark:bg-gray-900">
@@ -34,7 +34,7 @@ export default function CostOfLiving() {
                 .filter((city) => city.region === region)
                 .map((city) => (
                   <Link
-                    to={`${costOfLivingPageBase}?slug=${createSlug(city.name)}`}
+                    to={`${costOfLivingBase}/${createSlug(city.name)}`}
                     key={city.name}
                     className="group"
                   >

--- a/src/pages/CostOfLivingPage.jsx
+++ b/src/pages/CostOfLivingPage.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { ukCities, createSlug } from '../components/data/seo-data';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -27,13 +27,13 @@ const costOfLivingFAQs = [
 ];
 
 export default function CostOfLivingPage() {
-  const location = useLocation();
-  const costOfLivingPageBase = createPageUrl('CostOfLivingPage');
+  const { slug: rawSlug } = useParams();
+  const costOfLivingBase = createPageUrl('CostOfLiving');
+  const slug = (rawSlug || '').toLowerCase();
   const city = useMemo(() => {
-    const urlParams = new URLSearchParams(location.search);
-    const slug = urlParams.get('slug');
+    if (!slug) return undefined;
     return ukCities.find((c) => createSlug(c.name) === slug);
-  }, [location.search]);
+  }, [slug]);
 
   if (!city) {
     return (
@@ -41,7 +41,7 @@ export default function CostOfLivingPage() {
         <h1 className="text-2xl font-bold">City Not Found</h1>
         <p className="text-gray-600">The city you're looking for could not be found.</p>
         <Link
-          to={createPageUrl('CostOfLiving')}
+          to={costOfLivingBase}
           className="mt-4 inline-block text-blue-600 hover:underline"
         >
           &larr; Back to Cost of Living Explorer
@@ -59,7 +59,7 @@ export default function CostOfLivingPage() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="mb-6">
           <Link
-            to={createPageUrl('CostOfLiving')}
+            to={costOfLivingBase}
             className="text-sm text-gray-600 hover:text-gray-900 inline-flex items-center gap-2"
           >
             <ArrowLeft className="w-4 h-4" />
@@ -141,7 +141,7 @@ export default function CostOfLivingPage() {
                 {relatedCities.length > 0 ? (
                   relatedCities.map((relatedCity) => (
                     <Link
-                      to={`${costOfLivingPageBase}?slug=${createSlug(relatedCity.name)}`}
+                      to={`${costOfLivingBase}/${createSlug(relatedCity.name)}`}
                       key={relatedCity.name}
                       className="block p-3 bg-white border rounded-lg hover:bg-gray-100 transition-colors"
                     >

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -13,6 +13,8 @@ import CalculatorIndex from '../components/general/CalculatorIndex';
 import SeoHead from '@/components/seo/SeoHead';
 import { SeoProvider } from '@/components/seo/SeoContext';
 
+const COST_OF_LIVING_BASE_PATH = createPageUrl('CostOfLiving');
+
 // Define a mapping for page names to titles and descriptions for SEO
 // This object will be used to programmatically set SEO meta tags for each page.
 // In a larger application, this data might come from a CMS or a more complex routing configuration.
@@ -393,6 +395,31 @@ export default function Layout({ children, currentPageName }) {
   const [seoOverrides, setSeoOverrides] = useState({});
   const isHomePage = location.pathname === createPageUrl('Home');
 
+  const costOfLivingBaseSlug = useMemo(
+    () => COST_OF_LIVING_BASE_PATH.replace(/^\/+|\/+$/g, ''),
+    []
+  );
+
+  const getCostOfLivingSlug = useCallback(() => {
+    const pathnameSegments = (location.pathname || '')
+      .replace(/^\/+|\/+$/g, '')
+      .split('/')
+      .filter(Boolean);
+
+    if (pathnameSegments[0] === costOfLivingBaseSlug && pathnameSegments[1]) {
+      const segment = pathnameSegments[1];
+      try {
+        return decodeURIComponent(segment).toLowerCase();
+      } catch (error) {
+        return segment.toLowerCase();
+      }
+    }
+
+    const params = new URLSearchParams(location.search || '');
+    const slugFromQuery = params.get('slug');
+    return slugFromQuery ? slugFromQuery.trim().toLowerCase() : '';
+  }, [costOfLivingBaseSlug, location.pathname, location.search]);
+
   const rawOrigin =
     typeof window !== 'undefined' && window.location?.origin
       ? window.location.origin
@@ -405,9 +432,9 @@ export default function Layout({ children, currentPageName }) {
       return `${normalizedOrigin}/`;
     }
 
-    const dynamicCanonicalPages = new Set(['CostOfLiving', 'JobSalaries']);
+    const searchCanonicalPages = new Set(['JobSalaries']);
 
-    if (dynamicCanonicalPages.has(currentPageName)) {
+    if (searchCanonicalPages.has(currentPageName)) {
       const params = new URLSearchParams(location.search || '');
       const slug = params.get('slug');
       const canonicalParams = new URLSearchParams();
@@ -615,15 +642,11 @@ export default function Layout({ children, currentPageName }) {
       case 'PAYECalculator':
         return 'UK PAYE Calculator';
       case 'CostOfLiving': {
-        // hub page with optional slug
-        const params = new URLSearchParams(window.location.search);
-        const slug = params.get('slug');
+        const slug = getCostOfLivingSlug();
         return slug ? `Cost of Living in ${toTitleCase(slug)}` : 'UK Cost of Living Explorer';
       }
       case 'CostOfLivingPage': {
-        // dynamic city page
-        const params = new URLSearchParams(window.location.search);
-        const slug = params.get('slug');
+        const slug = getCostOfLivingSlug();
         return slug ? `Cost of Living in ${toTitleCase(slug)}` : 'UK Cost of Living Explorer';
       }
       case 'StudentLoanRepaymentCalculator':

--- a/src/pages/Sitemap.jsx
+++ b/src/pages/Sitemap.jsx
@@ -74,9 +74,9 @@ export default function Sitemap() {
     title: `${job.title} Salary`,
   }));
 
-  const costOfLivingPageBase = createPageUrl('CostOfLivingPage');
+  const costOfLivingBase = createPageUrl('CostOfLiving');
   const cityLinks = ukCities.map((city) => ({
-    url: `${costOfLivingPageBase}?slug=${createSlug(city.name)}`,
+    url: `${costOfLivingBase}/${createSlug(city.name)}`,
     title: `Cost of Living in ${city.name}`,
   }));
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -40,6 +40,9 @@ const LEGACY_REDIRECTS = {
 
 // Pull calculator config so we can auto-generate routes for entries with `page`
 import { calculatorCategories } from '../components/data/calculatorConfig';
+import { ukCities, createSlug } from '../components/data/seo-data';
+
+const COST_OF_LIVING_BASE_PATH = createPageUrl('CostOfLiving');
 
 // --- LAZY IMPORTS (calculators) ---
 const LazySalaryCalculatorUK = lazy(() => import('./SalaryCalculatorUK.jsx'));
@@ -229,14 +232,39 @@ const _slugToPageName = (() => {
     }
   });
 
+  const costOfLivingBase = COST_OF_LIVING_BASE_PATH.replace(/^\/+|\/+$/g, '');
+  if (costOfLivingBase) {
+    ukCities.forEach((city) => {
+      if (!city?.name) return;
+      const slug = createSlug(city.name);
+      if (!slug) return;
+      _registerSlug(map, `${costOfLivingBase}/${slug}`, 'CostOfLivingPage');
+    });
+  }
+
   return map;
 })();
+
+function LegacyCostOfLivingRedirect() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search || '');
+  const slug = params.get('slug');
+  const normalizedSlug = slug ? createSlug(slug) : '';
+  if (normalizedSlug) {
+    return <Navigate to={`${COST_OF_LIVING_BASE_PATH}/${normalizedSlug}`} replace />;
+  }
+  return <Navigate to={COST_OF_LIVING_BASE_PATH} replace />;
+}
 
 // Helper for Layout current page label
 function _getCurrentPage(pathname) {
   const normalizedPath = _normalizeSlug(pathname || '/');
   if (!normalizedPath || normalizedPath === 'home') {
     return 'Home';
+  }
+
+  if (normalizedPath.startsWith('cost-of-living/')) {
+    return 'CostOfLivingPage';
   }
 
   const segments = normalizedPath.split('/').filter(Boolean);
@@ -423,6 +451,7 @@ function PagesContent() {
           <Route path="/blog" element={<Blog />} />
           <Route path="/sitemap" element={<Sitemap />} />
           <Route path="/cost-of-living" element={<CostOfLiving />} />
+          <Route path="/cost-of-living/:slug" element={<CostOfLivingPage />} />
           <Route path="/uk-government-budget" element={<UKGovernmentBudget />} />
           <Route path="/terms-of-service" element={<TermsOfService />} />
           <Route path="/disclaimer" element={<Disclaimer />} />
@@ -431,7 +460,7 @@ function PagesContent() {
           <Route path="/blog-financial-psychology" element={<BlogFinancialPsychology />} />
           <Route path="/job-salary-page" element={<JobSalaryPage />} />
           <Route path="/jobsalarypage" element={<JobSalaryPage />} />
-          <Route path="/cost-of-living-page" element={<CostOfLivingPage />} />
+          <Route path="/cost-of-living-page" element={<LegacyCostOfLivingRedirect />} />
           <Route path="/uk-financial-stats" element={<UKFinancialStats />} />
           <Route path="/methodology" element={<Methodology />} />
           <Route path="/about" element={<About />} />


### PR DESCRIPTION
## Summary
- add a dedicated /cost-of-living/:slug route and legacy redirect for query based URLs
- update the cost of living hub, detail page, layout SEO helpers, sitemap and robots settings for slug paths
- refresh sitemap entry to point at the new canonical cost of living URL

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e019c7bbac8320b520715ac935fe66