### PR TITLE
Add severance and child benefit calculators

### DIFF
--- a/src/components/data/calculatorConfig.jsx
+++ b/src/components/data/calculatorConfig.jsx
@@ -147,6 +147,7 @@ export const calculatorCategories = [
           },
           {
             name: 'Severance Pay Calculator',
+            page: 'SeverancePayCalculator',
             url: createPageUrl('SeverancePayCalculator'),
             icon: FileText,
             status: 'active',
@@ -154,6 +155,7 @@ export const calculatorCategories = [
           },
           {
             name: 'Child Benefit Calculator',
+            page: 'ChildBenefitCalculator',
             url: createPageUrl('ChildBenefitCalculator'),
             icon: Baby,
             status: 'active',

--- a/src/pages/ChildBenefitCalculator.jsx
+++ b/src/pages/ChildBenefitCalculator.jsx
@@ -1,0 +1,390 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Baby, Calculator, AlertCircle, Percent } from 'lucide-react';
+import Breadcrumbs from '../components/general/Breadcrumbs';
+import CalculatorWrapper from '../components/calculators/CalculatorWrapper';
+import FAQSection from '../components/calculators/FAQSection';
+import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import AnimatedNumber from '../components/general/AnimatedNumber';
+import { createPageUrl } from '@/utils';
+
+const FIRST_CHILD_WEEKLY = 25.6;
+const ADDITIONAL_CHILD_WEEKLY = 16.95;
+const LOWER_THRESHOLD = 50000;
+const UPPER_THRESHOLD = 60000;
+
+const childBenefitFaqs = [
+  {
+    question: 'How much Child Benefit will I receive?',
+    answer:
+      'For 2024/25 the weekly rate is £25.60 for your eldest or only child and £16.95 for each additional child. Multiply the weekly figure by 52 to get the annual amount. Our calculator automatically applies these rates and shows the monthly value too.',
+  },
+  {
+    question: 'What is the High Income Child Benefit Charge?',
+    answer:
+      'If either partner has adjusted net income above £50,000 the government claws back 1% of your Child Benefit for every £100 over the threshold. Once income hits £60,000 the charge equals 100% of the benefit, effectively cancelling it out. Only the higher earner pays the charge.',
+  },
+  {
+    question: 'Should I still claim if my income is above £60,000?',
+    answer:
+      'Yes — registering keeps your National Insurance credits and protects your State Pension record. You can claim, then opt out of receiving the payments, or receive them and repay the charge through self-assessment.',
+  },
+];
+
+const relatedCalculators = [
+  {
+    name: 'Childcare Cost Calculator',
+    url: createPageUrl('ChildcareCostCalculator'),
+    description: 'Work out how much nursery or childcare support you need each month.',
+  },
+  {
+    name: 'Budget Planner',
+    url: createPageUrl('BudgetCalculator'),
+    description: 'Plan family spending alongside your benefit entitlement.',
+  },
+  {
+    name: 'Income Tax Calculator',
+    url: createPageUrl('IncomeTaxCalculator'),
+    description: 'Check how salary changes alter your adjusted net income.',
+  },
+];
+
+const formatCurrency = (value) =>
+  value.toLocaleString('en-GB', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+export default function ChildBenefitCalculator() {
+  const [children, setChildren] = useState('1');
+  const [income, setIncome] = useState('');
+  const [partnerIncome, setPartnerIncome] = useState('');
+
+  const [results, setResults] = useState(null);
+  const [hasCalculated, setHasCalculated] = useState(false);
+
+  const breadcrumbPath = useMemo(
+    () => [
+      { name: 'Home', url: createPageUrl('Home') },
+      { name: 'Family & Benefits', url: `${createPageUrl('Home')}#family-benefits` },
+      { name: 'Child Benefit Calculator' },
+    ],
+    []
+  );
+
+  const canonicalUrl = `https://www.calcmymoney.co.uk${createPageUrl('ChildBenefitCalculator')}`;
+
+  const performCalculation = () => {
+    const childrenNum = Math.max(Number(children) || 0, 0);
+    const incomeNum = Math.max(Number(income) || 0, 0);
+    const partnerIncomeNum = Math.max(Number(partnerIncome) || 0, 0);
+
+    if (childrenNum === 0) {
+      return {
+        weeklyBenefit: 0,
+        monthlyBenefit: 0,
+        annualBenefit: 0,
+        charge: 0,
+        netAnnual: 0,
+        netMonthly: 0,
+        netWeekly: 0,
+        chargeRate: 0,
+        highestIncome: Math.max(incomeNum, partnerIncomeNum),
+      };
+    }
+
+    const weeklyBenefit =
+      FIRST_CHILD_WEEKLY + Math.max(childrenNum - 1, 0) * ADDITIONAL_CHILD_WEEKLY;
+    const annualBenefit = weeklyBenefit * 52;
+    const monthlyBenefit = annualBenefit / 12;
+
+    const highestIncome = Math.max(incomeNum, partnerIncomeNum);
+    let chargeRate = 0;
+    if (highestIncome > LOWER_THRESHOLD) {
+      chargeRate = (highestIncome - LOWER_THRESHOLD) / (UPPER_THRESHOLD - LOWER_THRESHOLD);
+      chargeRate = Math.min(Math.max(chargeRate, 0), 1);
+    }
+
+    const charge = annualBenefit * chargeRate;
+    const netAnnual = Math.max(annualBenefit - charge, 0);
+
+    return {
+      weeklyBenefit,
+      monthlyBenefit,
+      annualBenefit,
+      charge,
+      netAnnual,
+      netMonthly: netAnnual / 12,
+      netWeekly: netAnnual / 52,
+      chargeRate,
+      highestIncome,
+    };
+  };
+
+  const handleCalculate = () => {
+    const calc = performCalculation();
+    setResults(calc);
+    setHasCalculated(true);
+  };
+
+  useEffect(() => {
+    setHasCalculated(false);
+  }, [children, income, partnerIncome]);
+
+  const incomeMessage = useMemo(() => {
+    if (!results) return '';
+    if (results.highestIncome <= LOWER_THRESHOLD) {
+      return 'No High Income Child Benefit Charge applies.';
+    }
+    if (results.highestIncome >= UPPER_THRESHOLD) {
+      return 'Charge equals 100% of the Child Benefit received. Consider opting out of payments to avoid repayments.';
+    }
+    const percent = (results.chargeRate * 100).toFixed(1);
+    return `Charge claws back ${percent}% of your Child Benefit.`;
+  }, [results]);
+
+  return (
+    <div className="bg-white dark:bg-gray-900">
+      <Helmet>
+        <title>Child Benefit Calculator UK | Check Entitlement & High Income Charge</title>
+        <meta
+          name="description"
+          content="Estimate your weekly Child Benefit, understand the High Income Child Benefit Charge and see how much you keep after repayments."
+        />
+        <link rel="canonical" href={canonicalUrl} />
+      </Helmet>
+
+      <div className="bg-blue-50 dark:bg-blue-900/30 border-b border-blue-200 dark:border-blue-800/60 non-printable">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <Breadcrumbs path={breadcrumbPath} />
+          <div className="text-center">
+            <h1 className="text-3xl md:text-4xl font-bold text-blue-900 dark:text-blue-100 mb-4">
+              UK Child Benefit Calculator
+            </h1>
+            <p className="text-lg text-blue-800/80 dark:text-blue-100/80 max-w-3xl mx-auto">
+              Enter your family size and household incomes to see how much Child Benefit you can
+              claim and whether the High Income Charge will claw it back.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="grid lg:grid-cols-2 gap-8">
+          <div className="space-y-6 non-printable">
+            <Card className="bg-white dark:bg-gray-800">
+              <CardHeader>
+                <CardTitle>Your household</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="children">Number of eligible children</Label>
+                  <Input
+                    id="children"
+                    type="number"
+                    min="0"
+                    value={children}
+                    onChange={(event) => setChildren(event.target.value)}
+                    placeholder="e.g. 2"
+                    className="dark:bg-gray-700"
+                  />
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="income">Your adjusted net income (£)</Label>
+                    <Input
+                      id="income"
+                      type="number"
+                      min="0"
+                      value={income}
+                      onChange={(event) => setIncome(event.target.value)}
+                      placeholder="e.g. 48000"
+                      className="dark:bg-gray-700"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="partnerIncome">Partner's adjusted net income (£)</Label>
+                    <Input
+                      id="partnerIncome"
+                      type="number"
+                      min="0"
+                      value={partnerIncome}
+                      onChange={(event) => setPartnerIncome(event.target.value)}
+                      placeholder="e.g. 52000"
+                      className="dark:bg-gray-700"
+                    />
+                  </div>
+                </div>
+                <Button onClick={handleCalculate} className="w-full text-lg">
+                  <Calculator className="w-5 h-5 mr-2" />
+                  Calculate Child Benefit
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-white dark:bg-gray-800">
+              <CardHeader>
+                <CardTitle>About the charge</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-gray-600 dark:text-gray-300">
+                <p>
+                  The High Income Child Benefit Charge is calculated using the higher earner's
+                  adjusted net income. If the higher earner crosses £50,000 the charge applies, even
+                  if the other partner earns much less.
+                </p>
+                <p>
+                  Adjusted net income is your total taxable income minus specific deductions such as
+                  pension contributions and Gift Aid. Reducing it can lower the charge, so consider
+                  salary sacrifice or pension top ups if appropriate.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-6 printable-area">
+            {hasCalculated && results ? (
+              <>
+                <Card className="bg-blue-100 dark:bg-blue-900/50 border-blue-200 dark:border-blue-700">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-blue-900 dark:text-blue-100">
+                      <Baby className="w-6 h-6" />
+                      Your Child Benefit summary
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="grid sm:grid-cols-3 gap-4 text-center">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-blue-700 dark:text-blue-200">
+                        Weekly
+                      </p>
+                      <p className="text-3xl font-semibold text-blue-900 dark:text-blue-100">
+                        £{formatCurrency(results.weeklyBenefit)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-blue-700 dark:text-blue-200">
+                        Monthly
+                      </p>
+                      <p className="text-3xl font-semibold text-blue-900 dark:text-blue-100">
+                        £{formatCurrency(results.monthlyBenefit)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-blue-700 dark:text-blue-200">
+                        Annual
+                      </p>
+                      <p className="text-3xl font-semibold text-blue-900 dark:text-blue-100">
+                        £{formatCurrency(results.annualBenefit)}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card className="bg-white dark:bg-gray-800">
+                  <CardHeader>
+                    <CardTitle>High Income Charge impact</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-sm text-gray-700 dark:text-gray-300">
+                    <div className="grid sm:grid-cols-2 gap-4">
+                      <div className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+                        <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                          Charge to repay
+                        </p>
+                        <p className="text-2xl font-semibold text-red-600 dark:text-red-300">
+                          £{formatCurrency(results.charge)}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          Due via self-assessment.
+                        </p>
+                      </div>
+                      <div className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+                        <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                          Effective reduction
+                        </p>
+                        <p className="text-2xl font-semibold text-blue-900 dark:text-blue-100 flex items-center justify-center gap-1">
+                          <Percent className="w-5 h-5" />
+                          {(results.chargeRate * 100).toFixed(1)}%
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          {incomeMessage}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-green-50 dark:bg-green-900/30">
+                      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        Amount kept after charge
+                      </p>
+                      <p className="text-3xl font-semibold text-green-800 dark:text-green-100">
+                        £<AnimatedNumber value={results.netAnnual} /> per year
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
+                        Equivalent to £{formatCurrency(results.netMonthly)} per month or £
+                        {formatCurrency(results.netWeekly)}
+                        per week.
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card className="bg-yellow-50 dark:bg-yellow-900/40 border-yellow-200 dark:border-yellow-700">
+                  <CardContent className="flex gap-3 items-start text-sm text-yellow-800 dark:text-yellow-100">
+                    <AlertCircle className="w-5 h-5 mt-0.5" />
+                    <p>
+                      Keep HMRC updated when your income changes. If you expect to exceed £60,000
+                      you can opt out of payments but remain registered to preserve National
+                      Insurance credits for State Pension entitlement.
+                    </p>
+                  </CardContent>
+                </Card>
+              </>
+            ) : (
+              <Card className="flex items-center justify-center h-full min-h-[320px] bg-white dark:bg-gray-800">
+                <div className="text-center text-gray-500 dark:text-gray-400 space-y-2">
+                  <Baby className="w-12 h-12 mx-auto" />
+                  <h2 className="text-xl font-semibold">Calculate your Child Benefit</h2>
+                  <p>Enter your details to see the annual value and any High Income Charge.</p>
+                </div>
+              </Card>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <CalculatorWrapper>
+        <div className="space-y-6 text-gray-700 dark:text-gray-300">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Understanding Child Benefit
+          </h2>
+          <p>
+            Child Benefit is a universal payment, but the High Income Charge means higher earners
+            may have to repay some or all of it. Use pension contributions or salary sacrifice to
+            reduce adjusted net income if you want to keep more of the benefit.
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>
+              Payments continue until your child is 16, or 20 if they stay in approved education or
+              training.
+            </li>
+            <li>
+              Only one parent can receive the payments, but you can switch who claims to manage the
+              High Income Charge.
+            </li>
+            <li>
+              Registering keeps your National Insurance credits even if you opt out of receiving the
+              money.
+            </li>
+          </ul>
+        </div>
+      </CalculatorWrapper>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 space-y-10">
+        <FAQSection faqs={childBenefitFaqs} />
+        <RelatedCalculators calculators={relatedCalculators} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -131,6 +131,11 @@ export const pageSeo = {
     description:
       "Estimate your Statutory Maternity Pay (SMP) with our free UK calculator. See how much you'll receive for the 39 weeks of your maternity leave.",
   },
+  SeverancePayCalculator: {
+    title: 'UK Severance Pay Calculator | Redundancy & Exit Package Estimate',
+    description:
+      'Estimate UK severance pay including statutory redundancy, notice pay, unused holiday and contractual enhancements.',
+  },
   InflationCalculator: {
     title: 'UK Inflation Calculator | Calculate the Changing Value of Money',
     description:
@@ -260,6 +265,11 @@ export const pageSeo = {
     title: 'Childcare Cost Calculator UK | Nursery Fees Estimator - Calculate My Money',
     description:
       'Estimate the weekly, monthly, and annual cost of childcare based on daily rates and the number of days required.',
+  },
+  ChildBenefitCalculator: {
+    title: 'UK Child Benefit Calculator | High Income Charge & Payments',
+    description:
+      'Check your weekly Child Benefit payments, see any High Income Child Benefit Charge and estimate how much you keep.',
   },
   TipCalculator: {
     title: 'UK Tip & Bill Splitting Calculator | Calculate My Money',

--- a/src/pages/SeverancePayCalculator.jsx
+++ b/src/pages/SeverancePayCalculator.jsx
@@ -1,0 +1,552 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Calculator, Briefcase, PiggyBank, AlertTriangle } from 'lucide-react';
+import Breadcrumbs from '../components/general/Breadcrumbs';
+import CalculatorWrapper from '../components/calculators/CalculatorWrapper';
+import FAQSection from '../components/calculators/FAQSection';
+import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import AnimatedNumber from '../components/general/AnimatedNumber';
+import { createPageUrl } from '@/utils';
+
+const MAX_WEEKLY_PAY = 700; // Statutory cap 2024/25 (England, Scotland, Wales)
+const MAX_SERVICE_YEARS = 20;
+const TAX_FREE_LIMIT = 30000;
+const DEFAULT_WORKING_DAYS = 5;
+
+const severanceFaqs = [
+  {
+    question: 'What counts as severance pay in the UK?',
+    answer:
+      'Severance packages usually combine statutory redundancy pay with contractual enhancements such as extra weeks of pay, payment in lieu of notice, and any outstanding holiday pay. Our calculator covers all of these elements so you can build a realistic payout estimate.',
+  },
+  {
+    question: 'Is all severance pay tax free?',
+    answer:
+      'The first £30,000 of a genuine redundancy or severance payment is normally free from Income Tax and National Insurance. Any amount above that threshold is taxable as earnings. Holiday pay and pay in lieu of notice are also taxable in the usual way.',
+  },
+  {
+    question: 'How are statutory redundancy weeks calculated?',
+    answer:
+      'Statutory redundancy pay awards 0.5, 1 or 1.5 weeks of capped pay for each full year of service depending on your age at the time of each year worked. Service is capped at 20 years and weekly pay is capped by law. Our calculation mirrors the official government formula.',
+  },
+];
+
+const relatedCalculators = [
+  {
+    name: 'Redundancy Pay Calculator',
+    url: createPageUrl('RedundancyPayCalculator'),
+    description: 'Work out the statutory redundancy you are entitled to receive.',
+  },
+  {
+    name: 'Emergency Fund Calculator',
+    url: createPageUrl('EmergencyFundCalculator'),
+    description: 'See how much cash buffer you should keep after leaving a job.',
+  },
+  {
+    name: 'Budget Planner',
+    url: createPageUrl('BudgetCalculator'),
+    description: 'Plan your monthly spending once your income changes.',
+  },
+];
+
+const calculateStatutoryRedundancy = (age, yearsOfService, weeklyPay) => {
+  const cappedWeeklyPay = Math.min(weeklyPay, MAX_WEEKLY_PAY);
+  const serviceYears = Math.min(Math.max(Math.floor(yearsOfService), 0), MAX_SERVICE_YEARS);
+
+  let totalWeeks = 0;
+  for (let i = 0; i < serviceYears; i += 1) {
+    const ageAtServiceYear = age - i;
+    if (ageAtServiceYear >= 41) {
+      totalWeeks += 1.5;
+    } else if (ageAtServiceYear >= 22) {
+      totalWeeks += 1;
+    } else {
+      totalWeeks += 0.5;
+    }
+  }
+
+  return {
+    totalWeeks,
+    cappedWeeklyPay,
+    statutoryPay: totalWeeks * cappedWeeklyPay,
+  };
+};
+
+const calculateNoticeWeeks = (yearsOfService) => {
+  if (yearsOfService <= 0) return 0;
+  if (yearsOfService < 2) return 1;
+  return Math.min(Math.floor(yearsOfService), 12);
+};
+
+const calculateHolidayPay = (unusedDays, weeklyPay, workingDays) => {
+  if (unusedDays <= 0 || weeklyPay <= 0 || workingDays <= 0) {
+    return { holidayPay: 0, dailyRate: 0 };
+  }
+  const days = Math.max(workingDays, 1);
+  const dailyRate = weeklyPay / days;
+  return {
+    dailyRate,
+    holidayPay: dailyRate * unusedDays,
+  };
+};
+
+export default function SeverancePayCalculator() {
+  const [age, setAge] = useState('');
+  const [yearsOfService, setYearsOfService] = useState('');
+  const [weeklyPay, setWeeklyPay] = useState('');
+  const [additionalWeeks, setAdditionalWeeks] = useState('0');
+  const [extraLumpSum, setExtraLumpSum] = useState('');
+  const [unusedHolidayDays, setUnusedHolidayDays] = useState('');
+  const [workingDaysPerWeek, setWorkingDaysPerWeek] = useState(`${DEFAULT_WORKING_DAYS}`);
+
+  const [results, setResults] = useState(null);
+  const [hasCalculated, setHasCalculated] = useState(false);
+
+  const breadcrumbPath = useMemo(
+    () => [
+      { name: 'Home', url: createPageUrl('Home') },
+      { name: 'Income & Employment', url: `${createPageUrl('Home')}#income-employment` },
+      { name: 'Severance Pay Calculator' },
+    ],
+    []
+  );
+
+  const canonicalUrl = `https://www.calcmymoney.co.uk${createPageUrl('SeverancePayCalculator')}`;
+
+  const performCalculation = () => {
+    const ageNum = Number(age) || 0;
+    const serviceNum = Number(yearsOfService) || 0;
+    const weeklyPayNum = Number(weeklyPay) || 0;
+    const additionalWeeksNum = Math.max(Number(additionalWeeks) || 0, 0);
+    const extraLumpSumNum = Math.max(Number(extraLumpSum) || 0, 0);
+    const unusedHolidayDaysNum = Math.max(Number(unusedHolidayDays) || 0, 0);
+    const workingDaysNum = Math.max(Number(workingDaysPerWeek) || DEFAULT_WORKING_DAYS, 1);
+
+    if (ageNum <= 0 || serviceNum <= 0 || weeklyPayNum <= 0) {
+      return null;
+    }
+
+    const statutory = calculateStatutoryRedundancy(ageNum, serviceNum, weeklyPayNum);
+    const noticeWeeks = calculateNoticeWeeks(serviceNum);
+    const noticePay = noticeWeeks * weeklyPayNum;
+
+    const { holidayPay, dailyRate } = calculateHolidayPay(
+      unusedHolidayDaysNum,
+      weeklyPayNum,
+      workingDaysNum
+    );
+
+    const enhancementPay = additionalWeeksNum * weeklyPayNum;
+
+    const totalBeforeTax =
+      statutory.statutoryPay + noticePay + holidayPay + enhancementPay + extraLumpSumNum;
+    const taxFreeAmount = Math.min(totalBeforeTax, TAX_FREE_LIMIT);
+    const taxableAmount = Math.max(totalBeforeTax - TAX_FREE_LIMIT, 0);
+
+    return {
+      statutory,
+      noticeWeeks,
+      noticePay,
+      holidayPay,
+      dailyRate,
+      enhancementPay,
+      extraLumpSum: extraLumpSumNum,
+      totalBeforeTax,
+      taxFreeAmount,
+      taxableAmount,
+    };
+  };
+
+  const handleCalculate = () => {
+    const calcResults = performCalculation();
+    setResults(calcResults);
+    setHasCalculated(true);
+  };
+
+  useEffect(() => {
+    setHasCalculated(false);
+  }, [
+    age,
+    yearsOfService,
+    weeklyPay,
+    additionalWeeks,
+    extraLumpSum,
+    unusedHolidayDays,
+    workingDaysPerWeek,
+  ]);
+
+  return (
+    <div className="bg-white dark:bg-gray-900">
+      <Helmet>
+        <title>UK Severance Pay Calculator | Estimate Redundancy & Exit Packages</title>
+        <meta
+          name="description"
+          content="Estimate your UK severance package, including statutory redundancy, notice pay, unused holiday pay and contractual enhancements."
+        />
+        <link rel="canonical" href={canonicalUrl} />
+      </Helmet>
+
+      <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <Breadcrumbs path={breadcrumbPath} />
+          <div className="text-center">
+            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+              UK Severance Pay Calculator
+            </h1>
+            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+              Model your potential payout when leaving a job. Combine statutory redundancy,
+              contractual enhancements, pay in lieu of notice and unused holiday pay.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="grid lg:grid-cols-2 gap-8">
+          <div className="space-y-6 non-printable">
+            <Card className="bg-white dark:bg-gray-800">
+              <CardHeader>
+                <CardTitle>Your employment details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="age">Age (years)</Label>
+                  <Input
+                    id="age"
+                    type="number"
+                    min="16"
+                    value={age}
+                    onChange={(event) => setAge(event.target.value)}
+                    placeholder="e.g. 45"
+                    className="dark:bg-gray-700"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="service">Full years of continuous service</Label>
+                  <Input
+                    id="service"
+                    type="number"
+                    min="0"
+                    value={yearsOfService}
+                    onChange={(event) => setYearsOfService(event.target.value)}
+                    placeholder="e.g. 12"
+                    className="dark:bg-gray-700"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Statutory redundancy pay is capped at 20 full years of service.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="weeklyPay">Average weekly pay before tax (£)</Label>
+                  <Input
+                    id="weeklyPay"
+                    type="number"
+                    min="0"
+                    value={weeklyPay}
+                    onChange={(event) => setWeeklyPay(event.target.value)}
+                    placeholder="e.g. 720"
+                    className="dark:bg-gray-700"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    For statutory redundancy the weekly amount is capped at £
+                    {MAX_WEEKLY_PAY.toLocaleString()}.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-white dark:bg-gray-800">
+              <CardHeader>
+                <CardTitle>Enhancements &amp; unused leave</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="additionalWeeks">Extra contractual weeks of pay</Label>
+                  <Input
+                    id="additionalWeeks"
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    value={additionalWeeks}
+                    onChange={(event) => setAdditionalWeeks(event.target.value)}
+                    placeholder="e.g. 4"
+                    className="dark:bg-gray-700"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Enter additional weeks offered by your employer (e.g. 2 weeks per year of
+                    service).
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="lumpSum">Extra lump sum (£)</Label>
+                  <Input
+                    id="lumpSum"
+                    type="number"
+                    min="0"
+                    value={extraLumpSum}
+                    onChange={(event) => setExtraLumpSum(event.target.value)}
+                    placeholder="e.g. 5000"
+                    className="dark:bg-gray-700"
+                  />
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="holidayDays">Unused holiday days</Label>
+                    <Input
+                      id="holidayDays"
+                      type="number"
+                      min="0"
+                      value={unusedHolidayDays}
+                      onChange={(event) => setUnusedHolidayDays(event.target.value)}
+                      placeholder="e.g. 8"
+                      className="dark:bg-gray-700"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="workingDays">Working days per week</Label>
+                    <Input
+                      id="workingDays"
+                      type="number"
+                      min="1"
+                      max="7"
+                      value={workingDaysPerWeek}
+                      onChange={(event) => setWorkingDaysPerWeek(event.target.value)}
+                      placeholder={`${DEFAULT_WORKING_DAYS}`}
+                      className="dark:bg-gray-700"
+                    />
+                  </div>
+                </div>
+                <Button onClick={handleCalculate} className="w-full text-lg">
+                  <Calculator className="w-5 h-5 mr-2" />
+                  Calculate severance package
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-6 printable-area">
+            {hasCalculated && results ? (
+              <>
+                <Card className="bg-blue-50 dark:bg-blue-900/40 border-blue-200 dark:border-blue-700">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-blue-900 dark:text-blue-100">
+                      <Briefcase className="w-6 h-6" />
+                      Estimated severance package
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="text-center space-y-3">
+                    <div className="text-sm uppercase tracking-wide text-blue-700 dark:text-blue-200">
+                      Total before tax
+                    </div>
+                    <div className="text-4xl font-bold text-blue-900 dark:text-blue-100">
+                      £<AnimatedNumber value={results.totalBeforeTax} />
+                    </div>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      Includes statutory redundancy, notice pay, unused holiday pay and contractual
+                      enhancements.
+                    </p>
+                  </CardContent>
+                </Card>
+
+                <Card className="bg-white dark:bg-gray-800">
+                  <CardHeader>
+                    <CardTitle>Breakdown</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-sm text-gray-700 dark:text-gray-300">
+                    <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="font-medium text-gray-900 dark:text-gray-100">
+                          Statutory redundancy pay
+                        </span>
+                        <span className="font-semibold">
+                          £
+                          {results.statutory.statutoryPay.toLocaleString('en-GB', {
+                            minimumFractionDigits: 2,
+                          })}
+                        </span>
+                      </div>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {results.statutory.totalWeeks.toFixed(1)} weeks at £
+                        {results.statutory.cappedWeeklyPay.toLocaleString('en-GB', {
+                          minimumFractionDigits: 2,
+                        })}{' '}
+                        per week (capped).
+                      </p>
+                    </div>
+
+                    <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="font-medium text-gray-900 dark:text-gray-100">
+                          Notice pay
+                        </span>
+                        <span className="font-semibold">
+                          £{results.noticePay.toLocaleString('en-GB', { minimumFractionDigits: 2 })}
+                        </span>
+                      </div>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {results.noticeWeeks} week{results.noticeWeeks === 1 ? '' : 's'} of pay in
+                        lieu of notice.
+                      </p>
+                    </div>
+
+                    {results.holidayPay > 0 && (
+                      <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="font-medium text-gray-900 dark:text-gray-100">
+                            Unused holiday pay
+                          </span>
+                          <span className="font-semibold">
+                            £
+                            {results.holidayPay.toLocaleString('en-GB', {
+                              minimumFractionDigits: 2,
+                            })}
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          Based on £
+                          {results.dailyRate.toLocaleString('en-GB', { minimumFractionDigits: 2 })}{' '}
+                          per day and your unused leave.
+                        </p>
+                      </div>
+                    )}
+
+                    {(results.enhancementPay > 0 || results.extraLumpSum > 0) && (
+                      <div className="grid gap-4">
+                        {results.enhancementPay > 0 && (
+                          <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+                            <div className="flex items-center justify-between mb-1">
+                              <span className="font-medium text-gray-900 dark:text-gray-100">
+                                Extra contractual weeks
+                              </span>
+                              <span className="font-semibold">
+                                £
+                                {results.enhancementPay.toLocaleString('en-GB', {
+                                  minimumFractionDigits: 2,
+                                })}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+                        {results.extraLumpSum > 0 && (
+                          <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+                            <div className="flex items-center justify-between mb-1">
+                              <span className="font-medium text-gray-900 dark:text-gray-100">
+                                Additional lump sum
+                              </span>
+                              <span className="font-semibold">
+                                £
+                                {results.extraLumpSum.toLocaleString('en-GB', {
+                                  minimumFractionDigits: 2,
+                                })}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card className="bg-green-50 dark:bg-green-900/30 border-green-200 dark:border-green-700">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-green-900 dark:text-green-100">
+                      <PiggyBank className="w-5 h-5" />
+                      Tax treatment summary
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="grid sm:grid-cols-2 gap-4 text-sm">
+                    <div className="p-4 bg-white/70 dark:bg-gray-900/40 rounded-lg border border-green-200 dark:border-green-700">
+                      <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                        Tax-free element
+                      </p>
+                      <p className="text-2xl font-semibold text-green-800 dark:text-green-100">
+                        £
+                        {results.taxFreeAmount.toLocaleString('en-GB', {
+                          minimumFractionDigits: 2,
+                        })}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        First £{TAX_FREE_LIMIT.toLocaleString()} of qualifying severance is usually
+                        tax free.
+                      </p>
+                    </div>
+                    <div className="p-4 bg-white/70 dark:bg-gray-900/40 rounded-lg border border-green-200 dark:border-green-700">
+                      <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                        Taxable amount
+                      </p>
+                      <p className="text-2xl font-semibold text-green-800 dark:text-green-100">
+                        £
+                        {results.taxableAmount.toLocaleString('en-GB', {
+                          minimumFractionDigits: 2,
+                        })}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        Income tax and National Insurance are due on this portion.
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card className="bg-yellow-50 dark:bg-yellow-900/30 border-yellow-200 dark:border-yellow-700">
+                  <CardContent className="flex gap-3 items-start text-sm text-yellow-800 dark:text-yellow-100">
+                    <AlertTriangle className="w-5 h-5 mt-0.5" />
+                    <p>
+                      This tool provides an indicative estimate. Always confirm figures with your
+                      employer, consult the ACAS guidance and seek professional advice for complex
+                      contractual arrangements.
+                    </p>
+                  </CardContent>
+                </Card>
+              </>
+            ) : (
+              <Card className="flex items-center justify-center h-full min-h-[320px] bg-white dark:bg-gray-800">
+                <div className="text-center text-gray-500 dark:text-gray-400 space-y-2">
+                  <Briefcase className="w-12 h-12 mx-auto" />
+                  <h2 className="text-xl font-semibold">Work out your severance package</h2>
+                  <p>Enter your details and employer terms to see a full breakdown.</p>
+                </div>
+              </Card>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <CalculatorWrapper>
+        <div className="space-y-6 text-gray-700 dark:text-gray-300">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            How the calculator works
+          </h2>
+          <p>
+            Severance packages vary widely between employers. We combine the statutory redundancy
+            calculation with common contractual elements so you can stress test different scenarios.
+            Adjust the extra contractual weeks and lump sum to mirror the deal on the table.
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>
+              <strong>Statutory redundancy pay:</strong> Based on age, full years of service (capped
+              at 20) and a weekly pay cap of £{MAX_WEEKLY_PAY.toLocaleString()}.
+            </li>
+            <li>
+              <strong>Notice pay:</strong> Automatically assumes one week per full year of service
+              (capped at 12). You can mirror an enhanced notice period by adding extra contractual
+              weeks.
+            </li>
+            <li>
+              <strong>Holiday pay:</strong> Converts unused holiday into cash using your weekly pay
+              and working pattern.
+            </li>
+          </ul>
+        </div>
+      </CalculatorWrapper>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 space-y-10">
+        <FAQSection faqs={severanceFaqs} />
+        <RelatedCalculators calculators={relatedCalculators} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Sitemap.jsx
+++ b/src/pages/Sitemap.jsx
@@ -61,10 +61,12 @@ export default function Sitemap() {
   const calculatorLinks = calculatorCategories
     .flatMap((category) =>
       category.subCategories.flatMap((sub) =>
-        sub.calculators.map((calc) => ({
-          url: calc.url,
-          title: calc.name,
-        }))
+        sub.calculators
+          .filter((calc) => calc.status === 'active')
+          .map((calc) => ({
+            url: calc.url,
+            title: calc.name,
+          }))
       )
     )
     .sort((a, b) => a.title.localeCompare(b.title));


### PR DESCRIPTION
## Summary
- add full-featured Severance Pay and Child Benefit calculator pages with SEO metadata, FAQs, and related tool links
- wire the new tools into the calculator config, dynamic routing, and layout SEO defaults
- ensure the sitemap only lists active calculators so deferred tools stay hidden

## Testing
- npm run lint *(fails: existing Prettier/style violations and legacy lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e023e6b7dc8320905e995da8d829d7