### PR TITLE
Add article metadata and JSON-LD for blog posts

### DIFF
--- a/src/components/data/pageSeo.js
+++ b/src/components/data/pageSeo.js
@@ -18,16 +18,52 @@ export const pageSeo = {
     title: 'Smart Money-Saving Tips for UK Families | Calculate My Money',
     description:
       'Discover practical tips for UK families to save money on groceries, energy bills, and everyday expenses. A complete guide to cut costs and budget effectively.',
+    ogType: 'article',
+    ogImage:
+      'https://images.unsplash.com/photo-1542838132-92c53300491e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    ogImageAlt: 'A family happily unpacking groceries in a bright, modern kitchen.',
+    twitterImage:
+      'https://images.unsplash.com/photo-1542838132-92c53300491e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    twitterImageAlt: 'A family happily unpacking groceries in a bright, modern kitchen.',
+    publishedTime: '2023-10-26T08:00:00+00:00',
+    modifiedTime: '2023-10-26T08:00:00+00:00',
+    author: 'CalcMyMoney Team',
+    section: 'Money Saving',
+    tags: ['Money Saving', 'Family Budgeting', 'Energy Bills', 'UK Finance'],
   },
   BlogDebtRepaymentStrategies: {
     title: 'Debt Snowball vs. Avalanche in the UK | Calculate My Money',
     description:
       'Compare the Debt Snowball and Debt Avalanche methods. Find the best strategy to pay off your debts in the UK, from credit cards to loans.',
+    ogType: 'article',
+    ogImage:
+      'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    ogImageAlt: 'Person organizing financial documents and calculating debt payments',
+    twitterImage:
+      'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    twitterImageAlt: 'Person organizing financial documents and calculating debt payments',
+    publishedTime: '2023-10-24T08:00:00+00:00',
+    modifiedTime: '2023-10-24T08:00:00+00:00',
+    author: 'CalcMyMoney Team',
+    section: 'Debt Management',
+    tags: ['Debt Repayment', 'Personal Finance', 'UK Debt Advice', 'Budgeting'],
   },
   BlogFinancialPsychology: {
     title: 'Your Relationship with Money: A Guide to Financial Psychology',
     description:
       'Understand the psychology behind your spending and saving habits. Learn how your money mindset impacts your financial health and future prosperity in the UK.',
+    ogType: 'article',
+    ogImage:
+      'https://images.unsplash.com/photo-1579621970563-ebec7560ff3e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    ogImageAlt: 'Person meditating with financial symbols and growth charts in the background',
+    twitterImage:
+      'https://images.unsplash.com/photo-1579621970563-ebec7560ff3e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    twitterImageAlt: 'Person meditating with financial symbols and growth charts in the background',
+    publishedTime: '2023-10-22T08:00:00+00:00',
+    modifiedTime: '2023-10-22T08:00:00+00:00',
+    author: 'CalcMyMoney Team',
+    section: 'Mindset',
+    tags: ['Financial Psychology', 'Money Mindset', 'Behavioural Finance', 'Personal Finance'],
   },
   Contact: {
     title: 'Contact Us | Calculate My Money',

--- a/src/components/seo/SeoHead.jsx
+++ b/src/components/seo/SeoHead.jsx
@@ -19,6 +19,11 @@ export default function SeoHead({
   ogImageAlt,
   ogSiteName,
   ogLocale,
+  articlePublishedTime,
+  articleModifiedTime,
+  articleSection,
+  articleAuthor,
+  articleTags,
   twitterCard = DEFAULT_TWITTER_CARD,
   twitterTitle,
   twitterDescription,
@@ -35,6 +40,7 @@ export default function SeoHead({
   const resolvedTwitterImageAlt = twitterImageAlt || ogImageAlt;
 
   const jsonLdArray = Array.isArray(jsonLd) ? jsonLd.filter(Boolean) : [];
+  const articleTagsArray = Array.isArray(articleTags) ? articleTags.filter(Boolean) : [];
 
   return (
     <Helmet>
@@ -43,6 +49,7 @@ export default function SeoHead({
       {canonical && <link rel="canonical" href={canonical} />}
       {robots && <meta name="robots" content={robots} />}
       {themeColor && <meta name="theme-color" content={themeColor} />}
+      {articleAuthor && <meta name="author" content={articleAuthor} />}
 
       {/* Open Graph */}
       {resolvedOgTitle && <meta property="og:title" content={resolvedOgTitle} />}
@@ -55,6 +62,13 @@ export default function SeoHead({
       <meta property="og:image:height" content="630" />
       {ogSiteName && <meta property="og:site_name" content={ogSiteName} />}
       {ogLocale && <meta property="og:locale" content={ogLocale} />}
+      {articlePublishedTime && <meta property="article:published_time" content={articlePublishedTime} />}
+      {articleModifiedTime && <meta property="article:modified_time" content={articleModifiedTime} />}
+      {articleSection && <meta property="article:section" content={articleSection} />}
+      {articleAuthor && <meta property="article:author" content={articleAuthor} />}
+      {articleTagsArray.map((tag, index) => (
+        <meta key={`article-tag-${index}`} property="article:tag" content={tag} />
+      ))}
 
       {/* Twitter */}
       {twitterCard && <meta name="twitter:card" content={twitterCard} />}

--- a/src/pages/BlogDebtRepaymentStrategies.jsx
+++ b/src/pages/BlogDebtRepaymentStrategies.jsx
@@ -1,21 +1,89 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { ArrowLeft, Calendar, User, Clock, TrendingDown, Target } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { useSeo } from '@/components/seo/SeoContext';
 
 export default function BlogDebtRepaymentStrategies() {
-  const post = {
-    title: 'Debt Snowball vs. Debt Avalanche: Which UK Debt Repayment Strategy is Right for You?',
-    category: 'Debt Management',
-    readTime: '6 min read',
-    author: 'CalcMyMoney Team',
-    date: 'October 24, 2023',
-    imageUrl:
-      'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    imageAlt: 'Person organizing financial documents and calculating debt payments',
-  };
+  const post = useMemo(
+    () => ({
+      title: 'Debt Snowball vs. Debt Avalanche: Which UK Debt Repayment Strategy is Right for You?',
+      category: 'Debt Management',
+      readTime: '6 min read',
+      author: 'CalcMyMoney Team',
+      displayDate: 'October 24, 2023',
+      publishedTime: '2023-10-24T08:00:00+00:00',
+      modifiedTime: '2023-10-24T08:00:00+00:00',
+      imageUrl:
+        'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      imageAlt: 'Person organizing financial documents and calculating debt payments',
+      tags: ['Debt Repayment', 'Personal Finance', 'UK Debt Advice', 'Budgeting'],
+    }),
+    []
+  );
+  const { setSeo, resetSeo, defaults } = useSeo();
+
+  const articleJsonLd = useMemo(() => {
+    const baseDescription =
+      defaults?.description ||
+      'Compare the debt snowball and debt avalanche methods to find the best UK debt repayment strategy for your situation.';
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: post.title,
+      description: baseDescription,
+      image: [post.imageUrl],
+      author: {
+        '@type': 'Organization',
+        name: post.author,
+      },
+      datePublished: post.publishedTime,
+      dateModified: post.modifiedTime,
+      articleSection: post.category,
+      keywords: post.tags.join(', '),
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id':
+          defaults?.canonical ||
+          defaults?.ogUrl ||
+          'https://www.calcmymoney.co.uk/blog-debt-repayment-strategies',
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Calculate My Money',
+        logo: {
+          '@type': 'ImageObject',
+          url: 'https://www.calcmymoney.co.uk/images/logo-high-res.png',
+        },
+      },
+    };
+  }, [defaults?.canonical, defaults?.description, defaults?.ogUrl, post]);
+
+  useEffect(() => {
+    const baseJsonLd = Array.isArray(defaults?.jsonLd) ? defaults.jsonLd : [];
+    const combinedJsonLd = articleJsonLd ? [...baseJsonLd, articleJsonLd] : baseJsonLd;
+
+    setSeo({
+      ogType: 'article',
+      ogImage: post.imageUrl,
+      ogImageAlt: post.imageAlt,
+      twitterImage: post.imageUrl,
+      twitterImageAlt: post.imageAlt,
+      articlePublishedTime: post.publishedTime,
+      articleModifiedTime: post.modifiedTime,
+      articleSection: post.category,
+      articleAuthor: post.author,
+      articleTags: post.tags,
+      jsonLd: combinedJsonLd,
+    });
+
+    return () => {
+      resetSeo();
+    };
+  }, [articleJsonLd, defaults?.jsonLd, post, resetSeo, setSeo]);
 
   return (
     <div className="bg-white dark:bg-gray-900 py-12">
@@ -43,7 +111,7 @@ export default function BlogDebtRepaymentStrategies() {
               </div>
               <div className="flex items-center gap-2">
                 <Calendar className="w-4 h-4" />
-                <time dateTime={post.date}>{post.date}</time>
+                <time dateTime={post.publishedTime}>{post.displayDate}</time>
               </div>
               <div className="flex items-center gap-2">
                 <Clock className="w-4 h-4" />

--- a/src/pages/BlogFinancialPsychology.jsx
+++ b/src/pages/BlogFinancialPsychology.jsx
@@ -1,21 +1,89 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { ArrowLeft, Calendar, User, Clock, Heart, Brain, Target } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { useSeo } from '@/components/seo/SeoContext';
 
 export default function BlogFinancialPsychology() {
-  const post = {
-    title: 'My Relationship with Money: A Guide to Financial Psychology',
-    category: 'Mindset',
-    readTime: '8 min read',
-    author: 'CalcMyMoney Team',
-    date: 'October 22, 2023',
-    imageUrl:
-      'https://images.unsplash.com/photo-1579621970563-ebec7560ff3e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    imageAlt: 'Person meditating with financial symbols and growth charts in the background',
-  };
+  const post = useMemo(
+    () => ({
+      title: 'My Relationship with Money: A Guide to Financial Psychology',
+      category: 'Mindset',
+      readTime: '8 min read',
+      author: 'CalcMyMoney Team',
+      displayDate: 'October 22, 2023',
+      publishedTime: '2023-10-22T08:00:00+00:00',
+      modifiedTime: '2023-10-22T08:00:00+00:00',
+      imageUrl:
+        'https://images.unsplash.com/photo-1579621970563-ebec7560ff3e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      imageAlt: 'Person meditating with financial symbols and growth charts in the background',
+      tags: ['Financial Psychology', 'Money Mindset', 'Behavioural Finance', 'Personal Finance'],
+    }),
+    []
+  );
+  const { setSeo, resetSeo, defaults } = useSeo();
+
+  const articleJsonLd = useMemo(() => {
+    const baseDescription =
+      defaults?.description ||
+      'Understand the psychology behind your spending and saving habits and how mindset impacts financial wellbeing in the UK.';
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: post.title,
+      description: baseDescription,
+      image: [post.imageUrl],
+      author: {
+        '@type': 'Organization',
+        name: post.author,
+      },
+      datePublished: post.publishedTime,
+      dateModified: post.modifiedTime,
+      articleSection: post.category,
+      keywords: post.tags.join(', '),
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id':
+          defaults?.canonical ||
+          defaults?.ogUrl ||
+          'https://www.calcmymoney.co.uk/blog-financial-psychology',
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Calculate My Money',
+        logo: {
+          '@type': 'ImageObject',
+          url: 'https://www.calcmymoney.co.uk/images/logo-high-res.png',
+        },
+      },
+    };
+  }, [defaults?.canonical, defaults?.description, defaults?.ogUrl, post]);
+
+  useEffect(() => {
+    const baseJsonLd = Array.isArray(defaults?.jsonLd) ? defaults.jsonLd : [];
+    const combinedJsonLd = articleJsonLd ? [...baseJsonLd, articleJsonLd] : baseJsonLd;
+
+    setSeo({
+      ogType: 'article',
+      ogImage: post.imageUrl,
+      ogImageAlt: post.imageAlt,
+      twitterImage: post.imageUrl,
+      twitterImageAlt: post.imageAlt,
+      articlePublishedTime: post.publishedTime,
+      articleModifiedTime: post.modifiedTime,
+      articleSection: post.category,
+      articleAuthor: post.author,
+      articleTags: post.tags,
+      jsonLd: combinedJsonLd,
+    });
+
+    return () => {
+      resetSeo();
+    };
+  }, [articleJsonLd, defaults?.jsonLd, post, resetSeo, setSeo]);
 
   return (
     <div className="bg-white dark:bg-gray-900 py-12">
@@ -43,7 +111,7 @@ export default function BlogFinancialPsychology() {
               </div>
               <div className="flex items-center gap-2">
                 <Calendar className="w-4 h-4" />
-                <time dateTime={post.date}>{post.date}</time>
+                <time dateTime={post.publishedTime}>{post.displayDate}</time>
               </div>
               <div className="flex items-center gap-2">
                 <Clock className="w-4 h-4" />

--- a/src/pages/BlogSmartMoneySavingTips.jsx
+++ b/src/pages/BlogSmartMoneySavingTips.jsx
@@ -1,21 +1,86 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { ArrowLeft, Calendar, User, Clock } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { useSeo } from '@/components/seo/SeoContext';
 
 export default function BlogSmartMoneySavingTips() {
-  const post = {
-    title: 'Smart Money-Saving Tips for UK Families: Tackling Groceries & Energy Bills',
-    category: 'Money Saving',
-    readTime: '7 min read',
-    author: 'CalcMyMoney Team',
-    date: 'October 26, 2023',
-    imageUrl:
-      'https://images.unsplash.com/photo-1542838132-92c53300491e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    imageAlt: 'A family happily unpacking groceries in a bright, modern kitchen.',
-  };
+  const post = useMemo(
+    () => ({
+      title: 'Smart Money-Saving Tips for UK Families: Tackling Groceries & Energy Bills',
+      category: 'Money Saving',
+      readTime: '7 min read',
+      author: 'CalcMyMoney Team',
+      displayDate: 'October 26, 2023',
+      publishedTime: '2023-10-26T08:00:00+00:00',
+      modifiedTime: '2023-10-26T08:00:00+00:00',
+      imageUrl:
+        'https://images.unsplash.com/photo-1542838132-92c53300491e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+      imageAlt: 'A family happily unpacking groceries in a bright, modern kitchen.',
+      tags: ['Money Saving', 'Family Budgeting', 'Energy Bills', 'UK Finance'],
+    }),
+    []
+  );
+  const { setSeo, resetSeo, defaults } = useSeo();
+
+  const articleJsonLd = useMemo(() => {
+    const baseDescription =
+      defaults?.description ||
+      'Discover practical tips for UK families to save money on groceries, energy bills, and everyday expenses.';
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: post.title,
+      description: baseDescription,
+      image: [post.imageUrl],
+      author: {
+        '@type': 'Organization',
+        name: post.author,
+      },
+      datePublished: post.publishedTime,
+      dateModified: post.modifiedTime,
+      articleSection: post.category,
+      keywords: post.tags.join(', '),
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': defaults?.canonical || defaults?.ogUrl || 'https://www.calcmymoney.co.uk/blog-smart-money-saving-tips',
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Calculate My Money',
+        logo: {
+          '@type': 'ImageObject',
+          url: 'https://www.calcmymoney.co.uk/images/logo-high-res.png',
+        },
+      },
+    };
+  }, [defaults?.canonical, defaults?.description, defaults?.ogUrl, post]);
+
+  useEffect(() => {
+    const baseJsonLd = Array.isArray(defaults?.jsonLd) ? defaults.jsonLd : [];
+    const combinedJsonLd = articleJsonLd ? [...baseJsonLd, articleJsonLd] : baseJsonLd;
+
+    setSeo({
+      ogType: 'article',
+      ogImage: post.imageUrl,
+      ogImageAlt: post.imageAlt,
+      twitterImage: post.imageUrl,
+      twitterImageAlt: post.imageAlt,
+      articlePublishedTime: post.publishedTime,
+      articleModifiedTime: post.modifiedTime,
+      articleSection: post.category,
+      articleAuthor: post.author,
+      articleTags: post.tags,
+      jsonLd: combinedJsonLd,
+    });
+
+    return () => {
+      resetSeo();
+    };
+  }, [articleJsonLd, defaults?.jsonLd, post, resetSeo, setSeo]);
 
   return (
     <div className="bg-white dark:bg-gray-900 py-12">
@@ -43,7 +108,7 @@ export default function BlogSmartMoneySavingTips() {
               </div>
               <div className="flex items-center gap-2">
                 <Calendar className="w-4 h-4" />
-                <time dateTime={post.date}>{post.date}</time>
+                <time dateTime={post.publishedTime}>{post.displayDate}</time>
               </div>
               <div className="flex items-center gap-2">
                 <Clock className="w-4 h-4" />

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -169,6 +169,11 @@ export default function Layout({ children, currentPageName }) {
       twitterDescription: pageData.twitterDescription || description,
       twitterImage: pageData.twitterImage || pageData.ogImage || defaultOgImage,
       twitterImageAlt: pageData.twitterImageAlt || pageData.ogImageAlt || defaultOgAlt,
+      articlePublishedTime: pageData.publishedTime,
+      articleModifiedTime: pageData.modifiedTime || pageData.publishedTime,
+      articleSection: pageData.section,
+      articleAuthor: pageData.author,
+      articleTags: pageData.tags,
       jsonLd,
     };
   }, [canonicalUrl, jsonLd, pageData]);


### PR DESCRIPTION
## Summary
- add article-focused OpenGraph configuration and metadata helpers for blog entries
- enhance the SEO head to render optional article details when supplied
- update blog detail pages to set article metadata overrides and inject BlogPosting JSON-LD payloads

## Testing
- npm run build *(fails: scripts/generate-sitemap.mjs cannot resolve the vite package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0eb0bcec083209112583e278b7dee