### PR TITLE
refine marketing palette and semantics

### DIFF
--- a/src/components/calculators/CalculatorWrapper.jsx
+++ b/src/components/calculators/CalculatorWrapper.jsx
@@ -2,11 +2,9 @@ import React from 'react';
 
 export default function CalculatorWrapper({ children }) {
   return (
-    <div className="bg-white dark:bg-gray-900 py-12 non-printable">
+    <div className="non-printable bg-background py-12">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="p-8 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-          {children}
-        </div>
+        <div className="rounded-lg border border-card-muted bg-card-muted p-8">{children}</div>
       </div>
     </div>
   );

--- a/src/components/calculators/FAQSection.jsx
+++ b/src/components/calculators/FAQSection.jsx
@@ -85,26 +85,23 @@ export default function FAQSection({
   }, [defaults?.jsonLd, disableSchema, faqSchema, setSeo]);
 
   return (
-    <Card className="bg-blue-50 dark:bg-gray-800 border-blue-200 dark:border-gray-700">
+    <Card className="border border-card-muted bg-card-muted">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-blue-900 dark:text-blue-400">
-          <HelpCircle className="w-5 h-5" />
+        <CardTitle className="flex items-center gap-2 text-primary">
+          <HelpCircle className="h-5 w-5" />
           {title}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         {faqs.map((faq, index) => (
-          <div
-            key={index}
-            className="border border-blue-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800/50 overflow-hidden"
-          >
+          <div key={index} className="overflow-hidden rounded-lg border border-card-muted bg-card">
             <button
               onClick={() => toggleFAQ(index)}
-              className="w-full p-4 text-left flex justify-between items-center hover:bg-blue-50 dark:hover:bg-gray-700/50 transition-colors"
+              className="flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-neutral-soft"
             >
-              <span className="font-medium text-gray-900 dark:text-gray-100">{faq.question}</span>
+              <span className="font-medium text-foreground">{faq.question}</span>
               <ChevronDown
-                className={`w-5 h-5 text-blue-600 dark:text-blue-400 transform transition-transform duration-300 ${openIndex === index ? 'rotate-180' : 'rotate-0'}`}
+                className={`h-5 w-5 text-primary transition-transform duration-300 ${openIndex === index ? 'rotate-180' : 'rotate-0'}`}
               />
             </button>
             <div
@@ -112,9 +109,7 @@ export default function FAQSection({
             >
               <div className="overflow-hidden">
                 <div className="px-4 pb-4 pt-1">
-                  <div className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
-                    {faq.answer}
-                  </div>
+                  <div className="text-sm leading-relaxed text-muted-foreground">{faq.answer}</div>
                 </div>
               </div>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,22 @@
     --brand-teal: 193 100% 50%; /* Teal */
     --brand-aqua: 164 100% 50%; /* Aqua */
 
+    /* Marketing surfaces */
+    --hero: 212 100% 97%;
+    --hero-foreground: 226 100% 18%;
+    --hero-accent: 193 95% 40%;
+    --hero-ring: 193 95% 46%;
+    --hero-gradient: radial-gradient(120% 120% at 50% -20%, hsl(var(--hero)) 0%, hsl(var(--background)) 70%);
+
+    --card-muted: 214 30% 96%;
+    --card-muted-foreground: 222 14% 32%;
+
+    --pill: 193 90% 92%;
+    --pill-foreground: 193 92% 26%;
+
+    --neutral-soft: 220 16% 96%;
+    --neutral-soft-foreground: 222 14% 26%;
+
     /* Light mode semantic tokens */
     --background: 0 0% 100%;
     --foreground: 222 14% 12%;
@@ -67,6 +83,21 @@
     --card-foreground: 0 0% 100%;
     --popover: 222 14% 12%;
     --popover-foreground: 0 0% 100%;
+
+    --hero: 222 14% 16%;
+    --hero-foreground: 0 0% 100%;
+    --hero-accent: var(--brand-aqua);
+    --hero-ring: var(--brand-aqua);
+    --hero-gradient: radial-gradient(120% 120% at 50% -20%, hsl(var(--hero)) 0%, hsl(var(--background)) 70%);
+
+    --card-muted: 222 14% 18%;
+    --card-muted-foreground: 215 15% 80%;
+
+    --pill: 193 82% 24%;
+    --pill-foreground: 193 92% 88%;
+
+    --neutral-soft: 222 14% 14%;
+    --neutral-soft-foreground: 0 0% 92%;
 
     --primary: var(--brand-teal);
     --primary-foreground: 222 14% 12%;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -142,15 +142,15 @@ export default function Home() {
   }, [hasQuery, setSeo, resetSeo]);
 
   return (
-    <div className="bg-white dark:bg-gray-900">
+    <div className="bg-background text-foreground">
       {/* Hero Section */}
-      <div className="bg-gray-50 dark:bg-gray-800/50 border-b dark:border-gray-700">
+      <div className="border-b border-border/70 bg-hero bg-hero-pattern">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
-          <div className="text-center max-w-4xl mx-auto">
-            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+          <div className="text-center max-w-4xl mx-auto text-hero-foreground">
+            <h1 className="text-4xl md:text-5xl font-bold text-hero-foreground mb-4">
               Free UK Salary, Tax & Mortgage Calculators
             </h1>
-            <p className="text-xl text-gray-600 dark:text-gray-300 mb-8">
+            <p className="text-xl text-muted-foreground mb-8">
               Use our fast, accurate UK calculators to estimate take-home pay, tax & NI, mortgage
               repayments, and savings growth for the 2025/26 tax year. Start with salary, tax,
               mortgage or finance tools below.
@@ -159,25 +159,25 @@ export default function Home() {
             {/* Search Bar */}
             <div className="max-w-2xl mx-auto mb-8">
               <div className="relative">
-                <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+                <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground/70" />
                 <Input
                   type="text"
                   placeholder="Search calculators... (e.g. salary, mortgage, tax)"
                   value={searchQuery}
                   onChange={handleSearchChange}
-                  className="pl-12 pr-4 py-4 text-lg border-2 border-gray-300 focus:border-blue-500 rounded-xl"
+                  className="pl-12 pr-4 py-4 text-lg border-2 border-input bg-background text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/15 rounded-xl"
                 />
               </div>
 
               {/* Search Results Dropdown */}
               {searchResults.length > 0 && (
-                <div className="absolute z-50 w-full max-w-2xl mx-auto mt-2 bg-white border border-gray-200 rounded-lg shadow-lg">
-                  <div className="p-2 max-h-64 overflow-y-auto">
+                <div className="absolute z-50 w-full max-w-2xl mx-auto mt-2 rounded-lg border border-border bg-card shadow-lg">
+                  <div className="p-2 max-h-64 overflow-y-auto text-left">
                     {searchResults.slice(0, 8).map((calc, index) => (
                       <Link
                         key={index}
                         to={calc.url}
-                        className="block p-3 hover:bg-gray-50 rounded-lg transition-colors"
+                        className="block rounded-lg p-3 transition-colors hover:bg-muted"
                         onClick={() => {
                           setSearchQuery('');
                           setSearchResults([]);
@@ -185,10 +185,10 @@ export default function Home() {
                       >
                         <div className="flex items-center justify-between">
                           <div>
-                            <p className="font-medium text-gray-900">{calc.name}</p>
-                            <p className="text-sm text-gray-600">{calc.description}</p>
+                            <p className="font-medium text-foreground">{calc.name}</p>
+                            <p className="text-sm text-muted-foreground">{calc.description}</p>
                             {(calc.category || calc.subCategory) && (
-                              <p className="text-xs text-gray-500">
+                              <p className="text-xs text-neutral-soft-foreground">
                                 {calc.category || 'Calculator'}{' '}
                                 {calc.subCategory ? `→ ${calc.subCategory}` : ''}
                               </p>
@@ -199,7 +199,7 @@ export default function Home() {
                               Coming Soon
                             </Badge>
                           ) : (
-                            <ExternalLink className="w-4 h-4 text-gray-400" />
+                            <ExternalLink className="h-4 w-4 text-muted-foreground/60" />
                           )}
                         </div>
                       </Link>
@@ -210,17 +210,17 @@ export default function Home() {
             </div>
 
             {/* Quick Stats */}
-            <div className="flex justify-center items-center gap-8 text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex items-center justify-center gap-8 text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
-                <Calculator className="w-4 h-4" />
+                <Calculator className="h-4 w-4 text-primary" />
                 <span>{stats.total} Calculators</span>
               </div>
               <div className="flex items-center gap-2">
-                <TrendingUp className="w-4 h-4" />
+                <TrendingUp className="h-4 w-4 text-primary" />
                 <span>{stats.active} Active</span>
               </div>
               <div className="flex items-center gap-2">
-                <Users className="w-4 h-4" />
+                <Users className="h-4 w-4 text-primary" />
                 <span>Free to Use</span>
               </div>
             </div>
@@ -229,23 +229,23 @@ export default function Home() {
       </div>
 
       {/* Hub Cards Section */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 -mt-16 relative z-10">
+      <div className="relative z-10 -mt-16 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {hubCards.map((card, index) => (
             <a
               key={index}
               href={card.link}
-              className="group block p-6 bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-xl hover:-translate-y-1 transform transition-all duration-300"
+              className="group block transform rounded-lg border border-card-muted bg-card p-6 shadow-md transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-xl"
             >
               <div className="flex items-center gap-4 mb-2">
-                <div className="bg-blue-100 p-3 rounded-full">
-                  <card.icon className="w-6 h-6 text-blue-600" />
+                <div className="rounded-full bg-pill p-3 text-pill-foreground">
+                  <card.icon className="h-6 w-6" />
                 </div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-700">
+                <h3 className="text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
                   {card.title}
                 </h3>
               </div>
-              <p className="text-sm text-gray-600">{card.description}</p>
+              <p className="text-sm text-muted-foreground">{card.description}</p>
             </a>
           ))}
         </div>
@@ -253,12 +253,12 @@ export default function Home() {
 
       {/* Featured/Popular Calculators */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="text-center mb-8">
-          <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-            <Calculator className="inline w-9 h-9 mr-2 text-blue-600" />
+        <div className="mb-8 text-center">
+          <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
+            <Calculator className="mr-2 inline h-9 w-9 text-primary" />
             Popular Calculators
           </h2>
-          <p className="text-gray-600 dark:text-gray-300">
+          <p className="text-muted-foreground">
             The most used financial calculators on our platform
           </p>
         </div>
@@ -270,25 +270,25 @@ export default function Home() {
               to={calc.url}
               onMouseEnter={() => calc.page && prefetchPage(calc.page)}
               onFocus={() => calc.page && prefetchPage(calc.page)}
-              className="group block p-6 bg-white border border-gray-200 rounded-lg hover:shadow-md hover:border-blue-300 transition-all duration-200"
+              className="group block rounded-lg border border-card-muted bg-card p-6 transition-all duration-200 hover:border-primary/50 hover:shadow-md"
             >
               <div className="flex items-center gap-3 mb-2">
-                <calc.icon className="w-5 h-5 text-blue-600" />
-                <h3 className="font-semibold text-gray-900 group-hover:text-blue-600">
+                <calc.icon className="h-5 w-5 text-primary" />
+                <h3 className="font-semibold text-foreground transition-colors group-hover:text-primary">
                   {calc.name}
                 </h3>
               </div>
-              <p className="text-sm text-gray-600 mb-2">{calc.description}</p>
-              <p className="text-xs text-gray-500">{calc.category}</p>
+              <p className="mb-2 text-sm text-muted-foreground">{calc.description}</p>
+              <p className="text-xs text-neutral-soft-foreground">{calc.category}</p>
             </Link>
           ))}
         </div>
       </div>
 
       {/* Homepage FAQ Section */}
-      <div className="bg-white py-16">
+      <div className="bg-background py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-10">
+          <h2 className="text-2xl md:text-3xl font-bold text-foreground text-center mb-10">
             Common Questions
           </h2>
           <FAQSection faqs={homepageFaqs} />
@@ -296,18 +296,18 @@ export default function Home() {
       </div>
 
       {/* Complete Calculator Directory */}
-      <div className="bg-gray-50 dark:bg-gray-800/50 py-16">
+      <div className="bg-neutral-soft py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+          <div className="mb-12 text-center">
+            <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
               Complete Calculator Directory
             </h2>
-            <p className="text-gray-600 dark:text-gray-300 mb-6">
+            <p className="mb-6 text-muted-foreground">
               Browse all {stats.total} financial calculators organized by category
             </p>
             <button
               onClick={() => setShowAllCalculators(!showAllCalculators)}
-              className="text-blue-600 hover:text-blue-800 font-medium"
+              className="font-medium text-primary transition-colors hover:text-primary/80"
             >
               {showAllCalculators ? 'Hide' : 'Show'} All Calculators
             </button>
@@ -318,13 +318,13 @@ export default function Home() {
             {calculatorCategories.map((category) => (
               <div key={category.slug} id={category.slug} className="scroll-mt-20">
                 {/* Category Header */}
-                <div className="flex items-center gap-4 mb-6 pb-3 border-b-2 border-gray-300">
-                  <category.icon className="w-8 h-8 text-blue-600" />
+                <div className="mb-6 flex items-center gap-4 border-b-2 border-card-muted pb-3">
+                  <category.icon className="h-8 w-8 text-primary" />
                   <div>
-                    <h3 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                    <h3 className="text-2xl font-bold text-foreground">
                       {category.name}
                     </h3>
-                    <p className="text-gray-600 dark:text-gray-300">{category.description}</p>
+                    <p className="text-muted-foreground">{category.description}</p>
                   </div>
                 </div>
 
@@ -332,7 +332,7 @@ export default function Home() {
                 <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {category.subCategories.map((subCategory) => (
                     <div key={subCategory.name} className="space-y-3">
-                      <h4 className="font-semibold text-lg text-gray-800 dark:text-gray-200 border-l-4 border-blue-500 pl-3">
+                      <h4 className="border-l-4 border-primary pl-3 text-lg font-semibold text-foreground">
                         {subCategory.name}
                       </h4>
                       <div className="space-y-2 pl-3">
@@ -345,15 +345,15 @@ export default function Home() {
                                   to={calc.url}
                                   onMouseEnter={() => calc.page && prefetchPage(calc.page)}
                                   onFocus={() => calc.page && prefetchPage(calc.page)}
-                                  className="flex-1 text-blue-600 hover:text-blue-800 hover:underline text-sm font-medium"
+                                  className="flex-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 hover:underline"
                                 >
                                   {calc.name}
                                 </Link>
                               ) : (
-                                <span className="flex-1 text-gray-400 text-sm">{calc.name}</span>
+                                <span className="flex-1 text-sm text-muted-foreground/60">{calc.name}</span>
                               )}
                               {calc.status === 'planned' && (
-                                <Badge variant="outline" className="text-xs ml-2">
+                                <Badge variant="outline" className="ml-2 text-xs text-primary">
                                   Coming Soon
                                 </Badge>
                               )}
@@ -368,22 +368,22 @@ export default function Home() {
           </div>
 
           {/* Quick Stats Footer */}
-          <div className="mt-16 text-center p-8 bg-white rounded-lg border border-gray-200">
-            <h3 className="text-xl font-semibold text-gray-900 mb-4">
+          <div className="mt-16 rounded-lg border border-card-muted bg-card p-8 text-center">
+            <h3 className="text-xl font-semibold text-foreground mb-4">
               Why Choose Our Calculators?
             </h3>
             <div className="grid md:grid-cols-3 gap-6 text-sm">
               <div>
-                <div className="text-3xl font-bold text-blue-600 mb-2">{stats.active}</div>
-                <p className="text-gray-600">Active Calculators</p>
+                <div className="mb-2 text-3xl font-bold text-primary">{stats.active}</div>
+                <p className="text-muted-foreground">Active Calculators</p>
               </div>
               <div>
-                <div className="text-3xl font-bold text-green-600 mb-2">100%</div>
-                <p className="text-gray-600">Free to Use</p>
+                <div className="mb-2 text-3xl font-bold text-hero-accent">100%</div>
+                <p className="text-muted-foreground">Free to Use</p>
               </div>
               <div>
-                <div className="text-3xl font-bold text-purple-600 mb-2">2025/26</div>
-                <p className="text-gray-600">Up-to-Date Tax Rates</p>
+                <div className="mb-2 text-3xl font-bold text-brandAqua">2025/26</div>
+                <p className="text-muted-foreground">Up-to-Date Tax Rates</p>
               </div>
             </div>
           </div>

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -371,7 +371,7 @@ export default function Layout({ children, currentPageName }) {
 
   return (
     <SeoProvider value={seoContextValue}>
-      <div className="min-h-screen bg-gray-50 text-gray-800">
+      <div className="min-h-screen bg-background text-foreground">
         <ScrollToTop />
         <SeoHead {...mergedSeo} />
       <style jsx global>{`
@@ -415,40 +415,39 @@ export default function Layout({ children, currentPageName }) {
       `}</style>
 
         {/* Header */}
-      <header className="bg-white/95 backdrop-blur-sm sticky top-0 z-40 border-b border-gray-200 non-printable">
-        <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex-shrink-0">
-              <Link to={createPageUrl('Home')} className="flex items-center space-x-2">
-                               {' '}
-                <img src="/app-icon.webp" alt="Calculate My Money Logo" className="h-8 w-8" />     
-                 <span className="font-bold text-xl text-gray-800">Calculate My Money</span>       
-                     {' '}
+      <header className="sticky top-0 z-40 border-b border-border/70 bg-background/95 backdrop-blur-sm non-printable">
+        <nav className="max-w-7xl mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+          <div className="flex-shrink-0">
+            <Link to={createPageUrl('Home')} className="flex items-center space-x-2">
+                             {' '}
+              <img src="/app-icon.webp" alt="Calculate My Money Logo" className="h-8 w-8" />
+               <span className="text-xl font-bold text-foreground">Calculate My Money</span>
+                   {' '}
+            </Link>
+          </div>
+
+          {/* Desktop Navigation - Simple Links */}
+          <div className="hidden items-center space-x-6 md:flex">
+            {mainNavLinks.map((link) => (
+              <Link
+                key={link.name}
+                to={link.url}
+                className="font-medium text-muted-foreground transition-colors hover:text-primary"
+              >
+                {link.name}
               </Link>
-            </div>
+            ))}
+          </div>
 
-            {/* Desktop Navigation - Simple Links */}
-            <div className="hidden md:flex md:items-center md:space-x-6">
-              {mainNavLinks.map((link) => (
-                <Link
-                  key={link.name}
-                  to={link.url}
-                  className="text-gray-700 hover:text-blue-600 font-medium transition-colors"
-                >
-                  {link.name}
-                </Link>
-              ))}
-            </div>
-
-            {/* Mobile Menu Button */}
-            <div className="md:hidden flex items-center">
+          {/* Mobile Menu Button */}
+          <div className="flex items-center md:hidden">
               <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
                 <SheetTrigger asChild>
-                  <Button variant="ghost" size="icon" className="text-gray-600">
+                  <Button variant="ghost" size="icon" className="text-muted-foreground">
                     <Menu className="h-6 w-6" />
                   </Button>
                 </SheetTrigger>
-                <SheetContent className="bg-white border-gray-200 w-[300px] sm:w-[340px] overflow-y-auto">
+                <SheetContent className="w-[300px] overflow-y-auto border-border bg-background sm:w-[340px]">
                   <SheetHeader>
                     <Link
                       to={createPageUrl('Home')}
@@ -460,7 +459,7 @@ export default function Layout({ children, currentPageName }) {
                         alt="Calculate My Money Logo"
                         className="h-8 w-8"
                       />
-                      <span className="font-bold text-xl text-gray-800">Calculate My Money</span>
+                      <span className="text-xl font-bold text-foreground">Calculate My Money</span>
                     </Link>
                   </SheetHeader>
 
@@ -471,7 +470,7 @@ export default function Layout({ children, currentPageName }) {
                         <SheetClose key={link.name} asChild>
                           <Link
                             to={link.url}
-                            className="block text-lg font-medium text-gray-700 hover:text-blue-600 py-2"
+                            className="block py-2 text-lg font-medium text-muted-foreground transition-colors hover:text-primary"
                           >
                             {link.name}
                           </Link>
@@ -483,28 +482,28 @@ export default function Layout({ children, currentPageName }) {
 
                     {/* Calculator Categories with Collapsibles */}
                     <div className="space-y-2">
-                      <h3 className="font-semibold text-gray-900 mb-3">Browse Calculators</h3>
+                      <h3 className="mb-3 font-semibold text-foreground">Browse Calculators</h3>
                       {calculatorCategories.map((category) => (
                         <Collapsible
                           key={category.slug}
                           open={openCategories[category.slug]}
                           onOpenChange={() => toggleCategory(category.slug)}
                         >
-                          <CollapsibleTrigger className="flex items-center justify-between w-full p-2 text-left hover:bg-gray-50 rounded-lg transition-colors">
-                            <div className="flex items-center gap-2">
-                              <category.icon className="w-4 h-4 text-gray-600" />
-                              <span className="font-medium text-gray-800">{category.name}</span>
+                          <CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg p-2 text-left transition-colors hover:bg-neutral-soft">
+                            <div className="flex items-center gap-2 text-muted-foreground">
+                              <category.icon className="h-4 w-4" />
+                              <span className="font-medium text-foreground">{category.name}</span>
                             </div>
                             {openCategories[category.slug] ? (
-                              <ChevronDown className="w-4 h-4 text-gray-500" />
+                              <ChevronDown className="h-4 w-4 text-muted-foreground" />
                             ) : (
-                              <ChevronRight className="w-4 h-4 text-gray-500" />
+                              <ChevronRight className="h-4 w-4 text-muted-foreground" />
                             )}
                           </CollapsibleTrigger>
                           <CollapsibleContent className="pl-6 mt-2 space-y-3">
                             {category.subCategories.map((subCategory) => (
                               <div key={subCategory.name} className="space-y-2">
-                                <h4 className="text-sm font-medium text-gray-700 border-b border-gray-200 pb-1">
+                                <h4 className="border-b border-card-muted pb-1 text-sm font-medium text-muted-foreground">
                                   {subCategory.name}
                                 </h4>
                                 <div className="space-y-1 pl-2">
@@ -512,10 +511,10 @@ export default function Layout({ children, currentPageName }) {
                                     <SheetClose key={calc.name} asChild>
                                       <Link
                                         to={calc.url}
-                                        className={`block text-sm py-1 transition-colors ${
+                                        className={`block py-1 text-sm transition-colors ${
                                           calc.status === 'active'
-                                            ? 'text-gray-600 hover:text-blue-600'
-                                            : 'text-gray-400 cursor-not-allowed'
+                                            ? 'text-muted-foreground hover:text-primary'
+                                            : 'cursor-not-allowed text-muted-foreground/60'
                                         }`}
                                       >
                                         {calc.name}{' '}
@@ -536,17 +535,16 @@ export default function Layout({ children, currentPageName }) {
                 </SheetContent>
               </Sheet>
             </div>
-          </div>
         </nav>
       </header>
 
       {/* Main Content */}
-      <main className="flex-1 printable-content bg-gray-50">
+      <main className="flex-1 bg-background printable-content">
         {/* NEW: Fallback H1 (only shows if page has no H1 and is one of the designated fallback pages) */}
         {needsFallbackH1 && fallbackH1Pages.has(currentPageName) && (
-          <div className="bg-white border-b border-gray-200 non-printable">
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+          <div className="non-printable border-b border-border bg-card">
+            <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+              <h1 className="text-3xl font-bold text-foreground md:text-4xl">
                 {getFallbackH1Text()}
               </h1>
             </div>
@@ -559,8 +557,8 @@ export default function Layout({ children, currentPageName }) {
       <CalculatorIndex />
 
       {/* Footer */}
-      <footer className="bg-white border-t border-gray-200 mt-16 non-printable">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <footer className="mt-16 border-t border-border bg-background non-printable">
+        <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
           <div className="grid md:grid-cols-5 gap-8">
             <div className="md:col-span-1">
               <Link to={createPageUrl('Home')} className="flex items-center space-x-2 mb-4">
@@ -569,21 +567,21 @@ export default function Layout({ children, currentPageName }) {
                   alt="Calculate My Money Logo"
                   className="h-8 w-8"
                 />
-                <span className="font-bold text-xl text-gray-800">Calculate My Money</span>
+                <span className="text-xl font-bold text-foreground">Calculate My Money</span>
               </Link>
-              <p className="text-gray-600 text-sm">
+              <p className="text-sm text-muted-foreground">
                 Free UK financial calculators for salary, tax, mortgages, pensions, budgets and
                 investments.
               </p>
             </div>
 
             <div>
-              <h4 className="font-semibold text-gray-900 mb-4">Popular Calculators</h4>
+              <h4 className="mb-4 font-semibold text-foreground">Popular Calculators</h4>
               <ul className="space-y-2">
                 <li>
                   <Link
                     to={createPageUrl('salary-calculator-uk')}
-                    className="text-gray-700 hover:text-blue-600 hover:underline"
+                    className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                   >
                     Salary Calculator
                   </Link>
@@ -591,7 +589,7 @@ export default function Layout({ children, currentPageName }) {
                 <li>
                   <Link
                     to={createPageUrl('mortgage-calculator')}
-                    className="text-gray-700 hover:text-blue-600 hover:underline"
+                    className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                   >
                     Mortgage Calculator
                   </Link>
@@ -599,7 +597,7 @@ export default function Layout({ children, currentPageName }) {
                 <li>
                   <Link
                     to={createPageUrl('budget-calculator')}
-                    className="text-gray-700 hover:text-blue-600 hover:underline"
+                    className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                   >
                     Budget Planner
                   </Link>
@@ -607,7 +605,7 @@ export default function Layout({ children, currentPageName }) {
                 <li>
                   <Link
                     to={createPageUrl('compound-interest-calculator')}
-                    className="text-gray-700 hover:text-blue-600 hover:underline"
+                    className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                   >
                     Compound Interest
                   </Link>
@@ -615,7 +613,7 @@ export default function Layout({ children, currentPageName }) {
                 <li>
                   <Link
                     to={createPageUrl('pension-calculator')}
-                    className="text-gray-700 hover:text-blue-600 hover:underline"
+                    className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                   >
                     Pension Calculator
                   </Link>
@@ -624,21 +622,21 @@ export default function Layout({ children, currentPageName }) {
             </div>
 
             <div>
-              <h4 className="font-semibold text-gray-900 mb-4">Categories</h4>
-              <ul className="space-y-2 text-gray-600">
+              <h4 className="mb-4 font-semibold text-foreground">Categories</h4>
+              <ul className="space-y-2 text-muted-foreground">
                 {calculatorCategories.slice(0, 6).map((category) => (
                   <li key={category.slug}>
                     {isHomePage ? (
                       <a
                         href={`#${category.slug}`}
-                        className="text-gray-700 hover:text-blue-600 hover:underline"
+                        className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                       >
                         {category.name}
                       </a>
                     ) : (
                       <Link
                         to={`${createPageUrl('Home')}#${category.slug}`}
-                        className="text-gray-700 hover:text-blue-600 hover:underline"
+                        className="text-muted-foreground transition-colors hover:text-primary hover:underline"
                       >
                         {category.name}
                       </Link>
@@ -649,85 +647,85 @@ export default function Layout({ children, currentPageName }) {
             </div>
 
             <div>
-              <h4 className="font-semibold text-gray-900 mb-4">Information</h4>
-              <ul className="space-y-2 text-gray-600">
+              <h4 className="mb-4 font-semibold text-foreground">Information</h4>
+              <ul className="space-y-2 text-muted-foreground">
                 <li>
-                  <Link to={createPageUrl('About')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('About')} className="transition-colors hover:text-primary">
                     About
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('methodology')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('methodology')} className="transition-colors hover:text-primary">
                     Methodology
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('blog')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('blog')} className="transition-colors hover:text-primary">
                     Blog
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('resources')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('resources')} className="transition-colors hover:text-primary">
                     Resources
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('uk-government-budget')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('uk-government-budget')} className="transition-colors hover:text-primary">
                     UK Budget Analysis
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('job-salaries')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('job-salaries')} className="transition-colors hover:text-primary">
                     Job Salaries
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('cost-of-living')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('cost-of-living')} className="transition-colors hover:text-primary">
                     Cost of Living
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('uk-financial-stats')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('uk-financial-stats')} className="transition-colors hover:text-primary">
                     Financial Stats
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('contact')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('contact')} className="transition-colors hover:text-primary">
                     Contact Us
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('sitemap')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('sitemap')} className="transition-colors hover:text-primary">
                     Sitemap
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('link-to-us')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('link-to-us')} className="transition-colors hover:text-primary">
                     Link to Us
                   </Link>
                 </li>
               </ul>
             </div>
             <div>
-              <h4 className="font-semibold text-gray-900 mb-4">Legal</h4>
-              <ul className="space-y-2 text-gray-600">
+              <h4 className="mb-4 font-semibold text-foreground">Legal</h4>
+              <ul className="space-y-2 text-muted-foreground">
                 <li>
-                  <Link to={createPageUrl('privacy-policy')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('privacy-policy')} className="transition-colors hover:text-primary">
                     Privacy Policy
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('cookie-policy')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('cookie-policy')} className="transition-colors hover:text-primary">
                     Cookie Policy
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('terms-of-service')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('terms-of-service')} className="transition-colors hover:text-primary">
                     Terms of Service
                   </Link>
                 </li>
                 <li>
-                  <Link to={createPageUrl('disclaimer')} className="hover:text-blue-600">
+                  <Link to={createPageUrl('disclaimer')} className="transition-colors hover:text-primary">
                     Disclaimer
                   </Link>
                 </li>
@@ -735,7 +733,7 @@ export default function Layout({ children, currentPageName }) {
             </div>
           </div>
 
-          <div className="border-t border-gray-200 mt-8 pt-8 text-center text-gray-500 text-sm">
+          <div className="mt-8 border-t border-border pt-8 text-center text-sm text-muted-foreground">
             <p>&copy; 2025 Calculate My Money - UK Financial Calculator Tools</p>
           </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,6 +57,24 @@ module.exports = {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
+        hero: {
+          DEFAULT: 'hsl(var(--hero))',
+          foreground: 'hsl(var(--hero-foreground))',
+          accent: 'hsl(var(--hero-accent))',
+          ring: 'hsl(var(--hero-ring))',
+        },
+        'card-muted': {
+          DEFAULT: 'hsl(var(--card-muted))',
+          foreground: 'hsl(var(--card-muted-foreground))',
+        },
+        pill: {
+          DEFAULT: 'hsl(var(--pill))',
+          foreground: 'hsl(var(--pill-foreground))',
+        },
+        neutral: {
+          soft: 'hsl(var(--neutral-soft))',
+          'soft-foreground': 'hsl(var(--neutral-soft-foreground))',
+        },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
@@ -82,6 +100,9 @@ module.exports = {
         brand: 'hsl(var(--brand-blue))',
         brandTeal: 'hsl(var(--brand-teal))',
         brandAqua: 'hsl(var(--brand-aqua))',
+      },
+      backgroundImage: {
+        'hero-pattern': 'var(--hero-gradient)',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Summary
- add marketing surface CSS variables for hero, card-muted, pill, and neutral tones plus a hero gradient token
- expose new semantic color aliases and hero background image helpers in Tailwind
- refresh the home hero, hub, featured listings, layout chrome, and calculator FAQ wrapper to consume the new palette tokens

## Testing
- npm run lint *(fails: existing eslint/prettier violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fa13c8b0832084ea9c44402cfcd9