### PR TITLE
Introduce shared layout primitives

### DIFF
--- a/src/components/common/Container.jsx
+++ b/src/components/common/Container.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+const widthClasses = {
+  default: 'max-w-7xl',
+  wide: 'max-w-6xl',
+  narrow: 'max-w-4xl',
+  snug: 'max-w-5xl',
+  full: 'max-w-none',
+};
+
+const paddingXClasses = {
+  default: 'px-4 sm:px-6 lg:px-8',
+  compact: 'px-4 sm:px-6',
+  wide: 'px-4 sm:px-8 lg:px-12',
+  none: 'px-0',
+};
+
+const paddingYClasses = {
+  none: 'py-0',
+  xs: 'py-4',
+  sm: 'py-6',
+  md: 'py-8',
+  lg: 'py-12',
+  xl: 'py-16',
+  '2xl': 'py-24',
+};
+
+const resolveClass = (preset, map) => {
+  if (preset == null) return '';
+  return map[preset] || preset;
+};
+
+export default function Container({
+  as: Component = 'div',
+  width = 'default',
+  paddingX = 'default',
+  paddingY = 'none',
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <Component
+      className={cn(
+        'mx-auto w-full',
+        resolveClass(width, widthClasses),
+        resolveClass(paddingX, paddingXClasses),
+        resolveClass(paddingY, paddingYClasses),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/components/common/README.md
+++ b/src/components/common/README.md
@@ -1,0 +1,44 @@
+# Common layout primitives
+
+This folder contains composable layout primitives that keep page spacing and widths consistent across the site.
+
+## `Container`
+
+`Container` centralises width and horizontal padding logic. It defaults to the standard `max-w-7xl` wrapper with responsive padding, but exposes props when a section needs something different.
+
+```jsx
+import Container from '@/components/common/Container';
+
+<Container paddingY="lg">
+  <h2>Consistent content width</h2>
+</Container>
+```
+
+Key props:
+
+- `width`: preset keys (`"default"`, `"wide"`, `"snug"`, `"narrow"`, `"full"`) or custom Tailwind classes.
+- `paddingX`: horizontal padding presets (`"default"`, `"compact"`, `"wide"`, `"none"`) or a custom string.
+- `paddingY`: vertical spacing preset (`"xs"` → `py-4`, `"sm"` → `py-6`, `"md"` → `py-8`, `"lg"` → `py-12`, etc.) or custom Tailwind classes. Defaults to no vertical padding so that sections opt-in explicitly.
+- `as`: renders a different HTML element if needed (e.g. `as="nav"`).
+
+## `Section`
+
+`Section` wraps content in a `Container` and applies site-wide background variants so that repeated sections remain visually aligned.
+
+```jsx
+import Section from '@/components/common/Section';
+
+<Section variant="muted" spacing="xl">
+  <h2 className="text-3xl font-semibold">FAQs</h2>
+</Section>
+```
+
+Key props:
+
+- `variant`: `"plain"` (default), `"muted"` (subtle tinted background), or `"inset"` (card-like container with border and shadow).
+- `spacing`: vertical padding preset passed to the inner `Container`. Set to `false` when the section manages its own spacing.
+- `width`/`paddingX`: forwarded to the underlying `Container` for layout tweaks.
+- `contentClassName`: styles applied to the immediate content wrapper. With `variant="inset"` this targets the inset card, otherwise it wraps your children directly.
+- `bleed`: set to `true` when you need to manage the container manually (e.g. full-bleed media sections).
+
+Keep new pages consistent by using these primitives instead of re-declaring `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8` blocks.

--- a/src/components/common/Section.jsx
+++ b/src/components/common/Section.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import Container from './Container';
+
+const sectionVariants = {
+  plain: 'bg-transparent',
+  muted: 'bg-muted/50',
+  inset: 'bg-transparent',
+};
+
+const insetBaseClasses = 'rounded-3xl border border-border/60 bg-card shadow-sm';
+
+export default function Section({
+  as: Component = 'section',
+  variant = 'plain',
+  width = 'default',
+  paddingX = 'default',
+  spacing = 'lg',
+  bleed = false,
+  className,
+  containerClassName,
+  contentClassName,
+  insetPadding = 'p-6 sm:p-8 md:p-10',
+  children,
+  ...props
+}) {
+  const sectionClassName = cn('w-full', sectionVariants[variant], className);
+
+  if (bleed) {
+    return (
+      <Component className={sectionClassName} {...props}>
+        {children}
+      </Component>
+    );
+  }
+
+  const containerPaddingY = spacing === false ? 'none' : spacing;
+
+  const content =
+    variant === 'inset' ? (
+      <div className={cn(insetBaseClasses, insetPadding, contentClassName)}>{children}</div>
+    ) : contentClassName ? (
+      <div className={contentClassName}>{children}</div>
+    ) : (
+      children
+    );
+
+  return (
+    <Component className={sectionClassName} {...props}>
+      <Container
+        width={width}
+        paddingX={paddingX}
+        paddingY={containerPaddingY}
+        className={cn(variant === 'inset' ? 'py-0' : null, containerClassName)}
+      >
+        {content}
+      </Container>
+    </Component>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -17,6 +17,7 @@ import { prefetchPage } from '@/utils/prefetchPage';
 import FAQSection from '../components/calculators/FAQSection';
 import { HandCoins, PoundSterling, Home as HomeIcon, PiggyBank } from 'lucide-react';
 import { useSeo } from '@/components/seo/SeoContext';
+import Section from '@/components/common/Section';
 
 const homepageFaqs = [
   {
@@ -144,92 +145,93 @@ export default function Home() {
   return (
     <div className="bg-background text-foreground">
       {/* Hero Section */}
-      <div className="border-b border-border/70 bg-hero bg-hero-pattern">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
-          <div className="text-center max-w-4xl mx-auto text-hero-foreground">
-            <h1 className="text-4xl md:text-5xl font-bold text-hero-foreground mb-4">
-              Free UK Salary, Tax & Mortgage Calculators
-            </h1>
-            <p className="text-xl text-muted-foreground mb-8">
-              Use our fast, accurate UK calculators to estimate take-home pay, tax & NI, mortgage
-              repayments, and savings growth for the 2025/26 tax year. Start with salary, tax,
-              mortgage or finance tools below.
-            </p>
+      <Section
+        variant="muted"
+        className="border-b border-border/70 bg-hero bg-hero-pattern"
+        spacing="py-16 md:py-20"
+        contentClassName="max-w-4xl mx-auto text-center text-hero-foreground"
+      >
+        <h1 className="text-4xl md:text-5xl font-bold text-hero-foreground mb-4">
+          Free UK Salary, Tax & Mortgage Calculators
+        </h1>
+        <p className="text-xl text-muted-foreground mb-8">
+          Use our fast, accurate UK calculators to estimate take-home pay, tax & NI, mortgage
+          repayments, and savings growth for the 2025/26 tax year. Start with salary, tax,
+          mortgage or finance tools below.
+        </p>
 
-            {/* Search Bar */}
-            <div className="max-w-2xl mx-auto mb-8">
-              <div className="relative">
-                <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground/70" />
-                <Input
-                  type="text"
-                  placeholder="Search calculators... (e.g. salary, mortgage, tax)"
-                  value={searchQuery}
-                  onChange={handleSearchChange}
-                  className="pl-12 pr-4 py-4 text-lg border-2 border-input bg-background text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/15 rounded-xl"
-                />
-              </div>
+        {/* Search Bar */}
+        <div className="max-w-2xl mx-auto mb-8">
+          <div className="relative">
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground/70" />
+            <Input
+              type="text"
+              placeholder="Search calculators... (e.g. salary, mortgage, tax)"
+              value={searchQuery}
+              onChange={handleSearchChange}
+              className="pl-12 pr-4 py-4 text-lg border-2 border-input bg-background text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/15 rounded-xl"
+            />
+          </div>
 
-              {/* Search Results Dropdown */}
-              {searchResults.length > 0 && (
-                <div className="absolute z-50 w-full max-w-2xl mx-auto mt-2 rounded-lg border border-border bg-card shadow-lg">
-                  <div className="p-2 max-h-64 overflow-y-auto text-left">
-                    {searchResults.slice(0, 8).map((calc, index) => (
-                      <Link
-                        key={index}
-                        to={calc.url}
-                        className="block rounded-lg p-3 transition-colors hover:bg-muted"
-                        onClick={() => {
-                          setSearchQuery('');
-                          setSearchResults([]);
-                        }}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div>
-                            <p className="font-medium text-foreground">{calc.name}</p>
-                            <p className="text-sm text-muted-foreground">{calc.description}</p>
-                            {(calc.category || calc.subCategory) && (
-                              <p className="text-xs text-neutral-soft-foreground">
-                                {calc.category || 'Calculator'}{' '}
-                                {calc.subCategory ? `→ ${calc.subCategory}` : ''}
-                              </p>
-                            )}
-                          </div>
-                          {calc.status === 'planned' ? (
-                            <Badge variant="secondary" className="text-xs">
-                              Coming Soon
-                            </Badge>
-                          ) : (
-                            <ExternalLink className="h-4 w-4 text-muted-foreground/60" />
-                          )}
-                        </div>
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Quick Stats */}
-            <div className="flex items-center justify-center gap-8 text-sm text-muted-foreground">
-              <div className="flex items-center gap-2">
-                <Calculator className="h-4 w-4 text-primary" />
-                <span>{stats.total} Calculators</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-primary" />
-                <span>{stats.active} Active</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 text-primary" />
-                <span>Free to Use</span>
+          {/* Search Results Dropdown */}
+          {searchResults.length > 0 && (
+            <div className="absolute z-50 w-full max-w-2xl mx-auto mt-2 rounded-lg border border-border bg-card shadow-lg">
+              <div className="p-2 max-h-64 overflow-y-auto text-left">
+                {searchResults.slice(0, 8).map((calc, index) => (
+                  <Link
+                    key={index}
+                    to={calc.url}
+                    className="block rounded-lg p-3 transition-colors hover:bg-muted"
+                    onClick={() => {
+                      setSearchQuery('');
+                      setSearchResults([]);
+                    }}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-foreground">{calc.name}</p>
+                        <p className="text-sm text-muted-foreground">{calc.description}</p>
+                        {(calc.category || calc.subCategory) && (
+                          <p className="text-xs text-neutral-soft-foreground">
+                            {calc.category || 'Calculator'}{' '}
+                            {calc.subCategory ? `→ ${calc.subCategory}` : ''}
+                          </p>
+                        )}
+                      </div>
+                      {calc.status === 'planned' ? (
+                        <Badge variant="secondary" className="text-xs">
+                          Coming Soon
+                        </Badge>
+                      ) : (
+                        <ExternalLink className="h-4 w-4 text-muted-foreground/60" />
+                      )}
+                    </div>
+                  </Link>
+                ))}
               </div>
             </div>
+          )}
+        </div>
+
+        {/* Quick Stats */}
+        <div className="flex items-center justify-center gap-8 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Calculator className="h-4 w-4 text-primary" />
+            <span>{stats.total} Calculators</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-primary" />
+            <span>{stats.active} Active</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-primary" />
+            <span>Free to Use</span>
           </div>
         </div>
-      </div>
+      </Section>
 
       {/* Hub Cards Section */}
-      <div className="relative z-10 -mt-16 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <Section className="relative z-10 -mt-16" spacing="lg">
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {hubCards.map((card, index) => (
             <a
@@ -249,10 +251,10 @@ export default function Home() {
             </a>
           ))}
         </div>
-      </div>
+      </Section>
 
       {/* Featured/Popular Calculators */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <Section spacing="lg">
         <div className="mb-8 text-center">
           <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
             <Calculator className="mr-2 inline h-9 w-9 text-primary" />
@@ -283,118 +285,114 @@ export default function Home() {
             </Link>
           ))}
         </div>
-      </div>
+      </Section>
 
       {/* Homepage FAQ Section */}
-      <div className="bg-background py-16">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl md:text-3xl font-bold text-foreground text-center mb-10">
-            Common Questions
-          </h2>
-          <FAQSection faqs={homepageFaqs} />
-        </div>
-      </div>
+      <Section spacing="xl" width="narrow">
+        <h2 className="text-2xl md:text-3xl font-bold text-foreground text-center mb-10">
+          Common Questions
+        </h2>
+        <FAQSection faqs={homepageFaqs} />
+      </Section>
 
       {/* Complete Calculator Directory */}
-      <div className="bg-neutral-soft py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mb-12 text-center">
-            <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
-              Complete Calculator Directory
-            </h2>
-            <p className="mb-6 text-muted-foreground">
-              Browse all {stats.total} financial calculators organized by category
-            </p>
-            <button
-              onClick={() => setShowAllCalculators(!showAllCalculators)}
-              className="font-medium text-primary transition-colors hover:text-primary/80"
-            >
-              {showAllCalculators ? 'Hide' : 'Show'} All Calculators
-            </button>
-          </div>
+      <Section className="bg-neutral-soft" spacing="xl">
+        <div className="mb-12 text-center">
+          <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
+            Complete Calculator Directory
+          </h2>
+          <p className="mb-6 text-muted-foreground">
+            Browse all {stats.total} financial calculators organized by category
+          </p>
+          <button
+            onClick={() => setShowAllCalculators(!showAllCalculators)}
+            className="font-medium text-primary transition-colors hover:text-primary/80"
+          >
+            {showAllCalculators ? 'Hide' : 'Show'} All Calculators
+          </button>
+        </div>
 
-          {/* Calculator Categories */}
-          {showAllCalculators ? (
-            <div className="space-y-12">
-              {calculatorCategories.map((category) => (
-                <div key={category.slug} id={category.slug} className="scroll-mt-20">
-                  {/* Category Header */}
-                  <div className="mb-6 flex items-center gap-4 border-b-2 border-card-muted pb-3">
-                    <category.icon className="h-8 w-8 text-primary" />
-                    <div>
-                      <h3 className="text-2xl font-bold text-foreground">
-                        {category.name}
-                      </h3>
-                      <p className="text-muted-foreground">{category.description}</p>
-                    </div>
-                  </div>
-
-                  {/* Sub-categories and Calculators */}
-                  <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {category.subCategories.map((subCategory) => (
-                      <div key={subCategory.name} className="space-y-3">
-                        <h4 className="border-l-4 border-primary pl-3 text-lg font-semibold text-foreground">
-                          {subCategory.name}
-                        </h4>
-                        <div className="space-y-2 pl-3">
-                          {subCategory.calculators
-                            .filter((calc) => showAllCalculators || calc.status === 'active')
-                            .map((calc, index) => (
-                              <div key={index} className="flex items-center justify-between group">
-                                {calc.status === 'active' ? (
-                                  <Link
-                                    to={calc.url}
-                                    onMouseEnter={() => calc.page && prefetchPage(calc.page)}
-                                    onFocus={() => calc.page && prefetchPage(calc.page)}
-                                    className="flex-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 hover:underline"
-                                  >
-                                    {calc.name}
-                                  </Link>
-                                ) : (
-                                  <span className="flex-1 text-sm text-muted-foreground/60">{calc.name}</span>
-                                )}
-                                {(calc.status === 'planned' || calc.status === 'pending') && (
-                                  <Badge variant="outline" className="ml-2 text-xs text-primary">
-                                    Coming Soon
-                                  </Badge>
-                                )}
-                              </div>
-                            ))}
-                        </div>
-                      </div>
-                    ))}
+        {/* Calculator Categories */}
+        {showAllCalculators ? (
+          <div className="space-y-12">
+            {calculatorCategories.map((category) => (
+              <div key={category.slug} id={category.slug} className="scroll-mt-20">
+                {/* Category Header */}
+                <div className="mb-6 flex items-center gap-4 border-b-2 border-card-muted pb-3">
+                  <category.icon className="h-8 w-8 text-primary" />
+                  <div>
+                    <h3 className="text-2xl font-bold text-foreground">
+                      {category.name}
+                    </h3>
+                    <p className="text-muted-foreground">{category.description}</p>
                   </div>
                 </div>
-              ))}
-            </div>
-          ) : (
-            <div className="text-center text-muted-foreground">
-              Expand the directory to explore every calculator we offer.
-            </div>
-          )}
 
-          {/* Quick Stats Footer */}
-          <div className="mt-16 rounded-lg border border-card-muted bg-card p-8 text-center">
-            <h3 className="text-xl font-semibold text-foreground mb-4">
-              Why Choose Our Calculators?
-            </h3>
-            <div className="grid md:grid-cols-3 gap-6 text-sm">
-              <div>
-                <div className="mb-2 text-3xl font-bold text-primary">{stats.active}</div>
-                <p className="text-muted-foreground">Active Calculators</p>
+                {/* Sub-categories and Calculators */}
+                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                  {category.subCategories.map((subCategory) => (
+                    <div key={subCategory.name} className="space-y-3">
+                      <h4 className="border-l-4 border-primary pl-3 text-lg font-semibold text-foreground">
+                        {subCategory.name}
+                      </h4>
+                      <div className="space-y-2 pl-3">
+                        {subCategory.calculators
+                          .filter((calc) => showAllCalculators || calc.status === 'active')
+                          .map((calc, index) => (
+                            <div key={index} className="flex items-center justify-between group">
+                              {calc.status === 'active' ? (
+                                <Link
+                                  to={calc.url}
+                                  onMouseEnter={() => calc.page && prefetchPage(calc.page)}
+                                  onFocus={() => calc.page && prefetchPage(calc.page)}
+                                  className="flex-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 hover:underline"
+                                >
+                                  {calc.name}
+                                </Link>
+                              ) : (
+                                <span className="flex-1 text-sm text-muted-foreground/60">{calc.name}</span>
+                              )}
+                              {(calc.status === 'planned' || calc.status === 'pending') && (
+                                <Badge variant="outline" className="ml-2 text-xs text-primary">
+                                  Coming Soon
+                                </Badge>
+                              )}
+                            </div>
+                          ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div>
-                <div className="mb-2 text-3xl font-bold text-hero-accent">100%</div>
-                <p className="text-muted-foreground">Free to Use</p>
-              </div>
-              <div>
-                <div className="mb-2 text-3xl font-bold text-brandAqua">2025/26</div>
-                <p className="text-muted-foreground">Up-to-Date Tax Rates</p>
-              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center text-muted-foreground">
+            Expand the directory to explore every calculator we offer.
+          </div>
+        )}
+
+        {/* Quick Stats Footer */}
+        <div className="mt-16 rounded-lg border border-card-muted bg-card p-8 text-center">
+          <h3 className="text-xl font-semibold text-foreground mb-4">
+            Why Choose Our Calculators?
+          </h3>
+          <div className="grid md:grid-cols-3 gap-6 text-sm">
+            <div>
+              <div className="mb-2 text-3xl font-bold text-primary">{stats.active}</div>
+              <p className="text-muted-foreground">Active Calculators</p>
+            </div>
+            <div>
+              <div className="mb-2 text-3xl font-bold text-hero-accent">100%</div>
+              <p className="text-muted-foreground">Free to Use</p>
+            </div>
+            <div>
+              <div className="mb-2 text-3xl font-bold text-brandAqua">2025/26</div>
+              <p className="text-muted-foreground">Up-to-Date Tax Rates</p>
             </div>
           </div>
         </div>
-      </div>
+      </Section>
     </div>
   );
 }

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -13,6 +13,7 @@ import { pageSeo, defaultOgImage, defaultOgAlt } from '../components/data/pageSe
 import CalculatorIndex from '../components/general/CalculatorIndex';
 import SeoHead from '@/components/seo/SeoHead';
 import { SeoProvider } from '@/components/seo/SeoContext';
+import Container from '@/components/common/Container';
 
 const COST_OF_LIVING_BASE_PATH = createPageUrl('CostOfLiving');
 
@@ -416,7 +417,7 @@ export default function Layout({ children, currentPageName }) {
 
         {/* Header */}
       <header className="sticky top-0 z-40 border-b border-border/70 bg-background/95 backdrop-blur-sm non-printable">
-        <nav className="max-w-7xl mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+        <Container as="nav" className="flex h-16 items-center justify-between" paddingY="none">
           <div className="flex-shrink-0">
             <Link to={createPageUrl('Home')} className="flex items-center space-x-2">
                              {' '}
@@ -535,7 +536,7 @@ export default function Layout({ children, currentPageName }) {
                 </SheetContent>
               </Sheet>
             </div>
-        </nav>
+        </Container>
       </header>
 
       {/* Main Content */}
@@ -543,11 +544,11 @@ export default function Layout({ children, currentPageName }) {
         {/* NEW: Fallback H1 (only shows if page has no H1 and is one of the designated fallback pages) */}
         {needsFallbackH1 && fallbackH1Pages.has(currentPageName) && (
           <div className="non-printable border-b border-border bg-card">
-            <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+            <Container paddingY="md">
               <h1 className="text-3xl font-bold text-foreground md:text-4xl">
                 {getFallbackH1Text()}
               </h1>
-            </div>
+            </Container>
           </div>
         )}
         {children}
@@ -558,7 +559,7 @@ export default function Layout({ children, currentPageName }) {
 
       {/* Footer */}
       <footer className="mt-16 border-t border-border bg-background non-printable">
-        <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+        <Container paddingY="lg">
           <div className="grid md:grid-cols-5 gap-8">
             <div className="md:col-span-1">
               <Link to={createPageUrl('Home')} className="flex items-center space-x-2 mb-4">
@@ -736,7 +737,7 @@ export default function Layout({ children, currentPageName }) {
           <div className="mt-8 border-t border-border pt-8 text-center text-sm text-muted-foreground">
             <p>&copy; 2025 Calculate My Money - UK Financial Calculator Tools</p>
           </div>
-        </div>
+        </Container>
       </footer>
 
         <CookieConsentBanner />

--- a/src/pages/SalaryCalculatorUK.jsx
+++ b/src/pages/SalaryCalculatorUK.jsx
@@ -42,6 +42,7 @@ import RelatedCalculators from '../components/calculators/RelatedCalculators'; /
 import Breadcrumbs from '../components/general/Breadcrumbs';
 import { createPageUrl } from '@/utils';
 import { Link } from 'react-router-dom'; // Added Link import
+import Section from '@/components/common/Section';
 
 // Adding structured data for better rich snippets
 const salaryCalculatorJsonLd = {
@@ -907,10 +908,12 @@ export default function SalaryCalculatorUK() {
 
       <div className="bg-white dark:bg-gray-900">
         {/* Page Header - Optimized for SEO */}
-        <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <Breadcrumbs path={breadcrumbPath} />
-            <div className="text-center">
+        <Section
+          className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable"
+          spacing="lg"
+        >
+          <Breadcrumbs path={breadcrumbPath} />
+          <div className="text-center">
               <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
                 UK Salary Calculator – Take-Home Pay 2025/26
               </h1>
@@ -956,11 +959,10 @@ export default function SalaryCalculatorUK() {
                 </p>
               </div>
             </div>
-          </div>
-        </div>
+        </Section>
 
         {/* Main Calculator Content */}
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Section spacing="md">
           <div className="print-title hidden">UK Salary Calculator Results</div>
 
           <div className="grid lg:grid-cols-5 gap-8 printable-grid-cols-1">
@@ -1721,7 +1723,7 @@ export default function SalaryCalculatorUK() {
               )}
             </div>
           </div>
-        </div>
+        </Section>
 
         <CalculatorWrapper>
           <div className="space-y-8">
@@ -1793,17 +1795,16 @@ export default function SalaryCalculatorUK() {
         />
 
         {/* Added: Explore Salary Tools section */}
-        <div className="bg-white dark:bg-gray-900 py-12 non-printable">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">
-              Explore Salary Tools
-            </h2>
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
-              <Link
-                to={createPageUrl('SalaryCalculatorTakeHomePay')}
-                className="block p-5 border rounded-lg hover:shadow-md hover:border-blue-300 transition dark:border-gray-700 dark:hover:border-blue-700 dark:bg-gray-800 dark:text-gray-100"
-              >
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+        <Section className="bg-white dark:bg-gray-900 non-printable" spacing="lg">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+            Explore Salary Tools
+          </h2>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <Link
+              to={createPageUrl('SalaryCalculatorTakeHomePay')}
+              className="block p-5 border rounded-lg hover:shadow-md hover:border-blue-300 transition dark:border-gray-700 dark:hover:border-blue-700 dark:bg-gray-800 dark:text-gray-100"
+            >
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100">
                   Take-Home Pay Calculator
                 </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
@@ -1844,64 +1845,71 @@ export default function SalaryCalculatorUK() {
                 </p>
               </Link>
             </div>
-          </div>
+        </Section>
         </div>
 
         {/* Visible FAQ section aligned with JSON-LD */}
-        <div className="bg-gray-50 dark:bg-gray-800/50 py-12 non-printable">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <FAQSection faqs={salaryHubFaqs} title="Salary Calculator FAQs" />
-            <p className="text-xs text-gray-500 mt-6">
-              Last updated: <time dateTime={LAST_UPDATED_ISO}>{LAST_UPDATED_DISPLAY}</time>
-            </p>
-          </div>
-        </div>
+        <Section
+          className="bg-gray-50 dark:bg-gray-800/50 non-printable"
+          spacing="lg"
+          width="narrow"
+        >
+          <FAQSection faqs={salaryHubFaqs} title="Salary Calculator FAQs" />
+          <p className="text-xs text-gray-500 mt-6">
+            Last updated: <time dateTime={LAST_UPDATED_ISO}>{LAST_UPDATED_DISPLAY}</time>
+          </p>
+        </Section>
 
         {/* Replace the second FAQ section to keep alignment */}
-        <div id="faq-section" className="bg-gray-50 dark:bg-gray-800/50 py-12 non-printable">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <FAQSection faqs={salaryHubFaqs} />
-          </div>
-        </div>
+        <Section
+          id="faq-section"
+          className="bg-gray-50 dark:bg-gray-800/50 non-printable"
+          spacing="lg"
+          width="narrow"
+        >
+          <FAQSection faqs={salaryHubFaqs} />
+        </Section>
 
         {/* Additional content section for keywords */}
-        <div className="bg-gray-50 dark:bg-gray-800/50 py-12 non-printable">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="text-center mb-8">
-              <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-                UK Salary Calculator - Everything You Need to Know
-              </h2>
+        <Section
+          className="bg-gray-50 dark:bg-gray-800/50 non-printable"
+          spacing="lg"
+          width="narrow"
+        >
+          <div className="text-center mb-8">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+              UK Salary Calculator - Everything You Need to Know
+            </h2>
+          </div>
+          <div className="grid md:grid-cols-2 gap-8 text-sm text-gray-700 dark:text-gray-300">
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                How Our UK Tax Calculator Works
+              </h3>
+              <ul className="space-y-2">
+                <li>• Accurate 2025/26 UK tax rates and thresholds</li>
+                <li>• Income tax calculation for all UK regions</li>
+                <li>• National Insurance contributions (Classes 1 & 4)</li>
+                <li>• Student loan repayment calculations (Plans 1-5)</li>
+                <li>• Pension contribution tax relief</li>
+                <li>• Scottish income tax rates included</li>
+              </ul>
             </div>
-            <div className="grid md:grid-cols-2 gap-8 text-sm text-gray-700 dark:text-gray-300">
-              <div>
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                  How Our UK Tax Calculator Works
-                </h3>
-                <ul className="space-y-2">
-                  <li>• Accurate 2025/26 UK tax rates and thresholds</li>
-                  <li>• Income tax calculation for all UK regions</li>
-                  <li>• National Insurance contributions (Classes 1 & 4)</li>
-                  <li>• Student loan repayment calculations (Plans 1-5)</li>
-                  <li>• Pension contribution tax relief</li>
-                  <li>• Scottish income tax rates included</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                  Perfect for UK Employees & Contractors
-                </h3>
-                <ul className="space-y-2">
-                  <li>• PAYE employees and contractors</li>
-                  <li>• Job offer salary comparisons</li>
-                  <li>• Annual and monthly salary planning</li>
-                  <li>• Gross to net pay calculations</li>
-                  <li>• Net to gross salary requirements</li>
-                  <li>• Tax code adjustments supported</li>
-                </ul>
-              </div>
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                Perfect for UK Employees & Contractors
+              </h3>
+              <ul className="space-y-2">
+                <li>• PAYE employees and contractors</li>
+                <li>• Job offer salary comparisons</li>
+                <li>• Annual and monthly salary planning</li>
+                <li>• Gross to net pay calculations</li>
+                <li>• Net to gross salary requirements</li>
+                <li>• Tax code adjustments supported</li>
+              </ul>
             </div>
           </div>
-        </div>
+        </Section>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- add reusable Container and Section components to centralise shared width, padding, and background variants
- refactor Layout, Home, and SalaryCalculatorUK pages to use the new primitives instead of repeating container markup
- document how to use the layout primitives for future pages in src/components/common/README.md

## Testing
- npm run lint *(fails: missing @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e103ed387c8320b609d9083a057bf0