### PR TITLE
Fix SalaryCalculator wrapper div imbalance

### DIFF
--- a/src/components/calculators/CalculatorWrapper.jsx
+++ b/src/components/calculators/CalculatorWrapper.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import { cn } from '@/lib/utils';
 
-export default function CalculatorWrapper({ children }) {
+export default function CalculatorWrapper({ children, className = '' }) {
   return (
     <div className="non-printable bg-background py-12">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="rounded-lg border border-card-muted bg-card-muted p-8">{children}</div>
+        <div className={cn('rounded-lg border border-card-muted bg-card-muted p-8', className)}>
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/SalaryCalculatorUK.jsx
+++ b/src/pages/SalaryCalculatorUK.jsx
@@ -1723,53 +1723,51 @@ export default function SalaryCalculatorUK() {
           </div>
         </div>
 
-        <CalculatorWrapper>
-          <div className="space-y-8">
-            <section>
-              <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
-                Calculate Your Take-Home Pay
-              </h2>
-              <p className="text-gray-700 dark:text-gray-300">
-                The UK Salary Calculator is an essential tool for anyone employed in the United
-                Kingdom. It demystifies your payslip by translating your gross annual salary—the
-                headline figure offered in a job contract—into your net take-home pay, which is the
-                actual amount that arrives in your bank account. This calculation involves
-                subtracting all mandatory deductions, including Income Tax, National Insurance, and,
-                if applicable, pension contributions and student loan repayments. Our calculator is
-                kept up-to-date with the latest tax thresholds for England, Scotland, Wales, and
-                Northern Ireland, ensuring you receive an accurate and reliable estimate.
-              </p>
-            </section>
-            <section>
-              <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
-                Pro-Rata & Pay Frequency (weekly, monthly)
-              </h2>
-              <p className="text-gray-700 dark:text-gray-300">
-                Our calculator seamlessly handles various pay frequencies. Whether you are paid
-                annually, monthly, weekly, or daily, you can input your gross pay for that period,
-                and the tool will annualize it to provide a complete tax breakdown. For part-time
-                workers, our dedicated{' '}
-                <a
-                  href={createPageUrl('ProRataSalaryCalculator')}
-                  className="text-blue-600 hover:underline"
-                >
-                  Pro Rata Salary Calculator
-                </a>{' '}
-                can help you determine your equivalent earnings.
-              </p>
-            </section>
-            <section>
-              <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
-                Student Loan & Pension Options
-              </h2>
-              <p className="text-gray-700 dark:text-gray-300">
-                Use the 'Advanced Options' to tailor the calculation to your specific circumstances.
-                You can select your student loan plan (including Plan 1, 2, 4, 5, and Postgraduate)
-                and specify your workplace pension contributions as either a percentage or a fixed
-                monthly amount. These are factored into your take‑home pay.
-              </p>
-            </section>
-          </div>
+        <CalculatorWrapper className="space-y-8">
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+              Calculate Your Take-Home Pay
+            </h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              The UK Salary Calculator is an essential tool for anyone employed in the United
+              Kingdom. It demystifies your payslip by translating your gross annual salary—the
+              headline figure offered in a job contract—into your net take-home pay, which is the
+              actual amount that arrives in your bank account. This calculation involves
+              subtracting all mandatory deductions, including Income Tax, National Insurance, and,
+              if applicable, pension contributions and student loan repayments. Our calculator is
+              kept up-to-date with the latest tax thresholds for England, Scotland, Wales, and
+              Northern Ireland, ensuring you receive an accurate and reliable estimate.
+            </p>
+          </section>
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+              Pro-Rata & Pay Frequency (weekly, monthly)
+            </h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              Our calculator seamlessly handles various pay frequencies. Whether you are paid
+              annually, monthly, weekly, or daily, you can input your gross pay for that period,
+              and the tool will annualize it to provide a complete tax breakdown. For part-time
+              workers, our dedicated{' '}
+              <a
+                href={createPageUrl('ProRataSalaryCalculator')}
+                className="text-blue-600 hover:underline"
+              >
+                Pro Rata Salary Calculator
+              </a>{' '}
+              can help you determine your equivalent earnings.
+            </p>
+          </section>
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+              Student Loan & Pension Options
+            </h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              Use the 'Advanced Options' to tailor the calculation to your specific circumstances.
+              You can select your student loan plan (including Plan 1, 2, 4, 5, and Postgraduate)
+              and specify your workplace pension contributions as either a percentage or a fixed
+              monthly amount. These are factored into your take‑home pay.
+            </p>
+          </section>
         </CalculatorWrapper>
 
         <RelatedCalculators


### PR DESCRIPTION
## Summary
- allow `CalculatorWrapper` to accept an optional `className` that merges with its inner container styling
- remove the redundant wrapper `<div>` in `SalaryCalculatorUK` by passing the spacing class directly to `CalculatorWrapper`, balancing the JSX tree

## Testing
- npm run build *(fails: scripts/generate-sitemap.mjs cannot find package 'vite')*


------
https://chatgpt.com/codex/tasks/task_e_68e1083115388320b63e3e5199ae4aac