### PR TITLE
Adjust base heading clamp size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -150,7 +150,7 @@
     line-height: 1.05;
     text-wrap: balance;
     color: hsl(var(--foreground));
-    font-size: clamp(2.75rem, 2.35rem + 1.5vw, 3.65rem);
+    font-size: clamp(2.25rem, 1.9rem + 1vw, 3rem);
   }
 
   h2,


### PR DESCRIPTION
## Summary
- reduce the base h1/.heading-1 clamp to align with Tailwind text-4xl/5xl scale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1271f9928832092fa0c15352bb0de