### PR TITLE
Standardize heading components across calculator pages

### DIFF
--- a/src/pages/AmortizationCalculator.jsx
+++ b/src/pages/AmortizationCalculator.jsx
@@ -8,6 +8,7 @@ import { PoundSterling, Calculator, Percent, Calendar, FileSpreadsheet } from 'l
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import {
+import Heading from '@/components/common/Heading';
   AreaChart,
   Area,
   XAxis,
@@ -121,9 +122,9 @@ export default function AmortizationCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Loan Amortization Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Generate a complete payment schedule for your mortgage or loan. See how much of each
               payment goes to principal vs. interest.

--- a/src/pages/AnnuityCalculator.jsx
+++ b/src/pages/AnnuityCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Calculator, TrendingUp, Calendar, Percent } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const annuityFAQs = [
   {
@@ -72,9 +73,9 @@ export default function AnnuityCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Annuity Calculator UK
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Estimate the regular income you could receive from your pension pot with an annuity.
             </p>

--- a/src/pages/BRRRRCalculator.jsx
+++ b/src/pages/BRRRRCalculator.jsx
@@ -19,6 +19,7 @@ import {
 import ExportActions from '../components/calculators/ExportActions';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
+import Heading from '@/components/common/Heading';
   Accordion,
   AccordionContent,
   AccordionItem,
@@ -225,9 +226,9 @@ export default function BRRRRCalculator() {
           <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
               <div className="text-center">
-                <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+                <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
                   UK Property Investment Calculator
-                </h1>
+                </Heading>
                 <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
                   Analyse your property deal: Calculate flip profits or full BRRRR strategy returns.
                   Perfect for UK property investors and developers.

--- a/src/pages/BlogDebtRepaymentStrategies.jsx
+++ b/src/pages/BlogDebtRepaymentStrategies.jsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Calendar, User, Clock, TrendingDown, Target } from 'lucide-r
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { useSeo } from '@/components/seo/SeoContext';
+import Heading from '@/components/common/Heading';
 
 const createUnsplashUrl = (baseUrl, params, width) => `${baseUrl}?${params}&w=${width}`;
 
@@ -144,9 +145,9 @@ export default function BlogDebtRepaymentStrategies() {
             <span className="bg-red-100 text-red-800 px-3 py-1 rounded-full text-sm font-medium dark:bg-red-900/50 dark:text-red-300">
               {post.category}
             </span>
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mt-4 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mt-4 mb-4">
               {post.title}
-            </h1>
+            </Heading>
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600 dark:text-gray-400">
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4" />

--- a/src/pages/BlogFinancialPsychology.jsx
+++ b/src/pages/BlogFinancialPsychology.jsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Calendar, User, Clock, Brain, Target } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { useSeo } from '@/components/seo/SeoContext';
+import Heading from '@/components/common/Heading';
 
 const createUnsplashUrl = (baseUrl, params, width) => `${baseUrl}?${params}&w=${width}`;
 
@@ -157,9 +158,9 @@ export default function BlogFinancialPsychology() {
             <span className="bg-purple-100 text-purple-800 px-3 py-1 rounded-full text-sm font-medium dark:bg-purple-900/50 dark:text-purple-300">
               {post.category}
             </span>
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mt-4 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mt-4 mb-4">
               {post.title}
-            </h1>
+            </Heading>
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600 dark:text-gray-400">
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4" />

--- a/src/pages/BreakEvenCalculator.jsx
+++ b/src/pages/BreakEvenCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Target, TrendingUp } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const breakEvenFAQs = [
   {
@@ -93,9 +94,9 @@ export default function BreakEvenCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Business Break-Even Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate how many units you need to sell to break even and start making profit.
               Essential for pricing and business planning.

--- a/src/pages/BudgetCalculator.jsx
+++ b/src/pages/BudgetCalculator.jsx
@@ -17,6 +17,7 @@ import {
 import ExportActions from '../components/calculators/ExportActions';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils'; // Imported createPageUrl from utils
+import Heading from '@/components/common/Heading';
 
 // Define placeholder data for government budget
 const governmentBudget2025 = {
@@ -135,9 +136,9 @@ export default function BudgetCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Budget Planner
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               A good budget is the foundation of financial freedom. Tell your money where to go,
               instead of wondering where it went.

--- a/src/pages/BusinessLoanCalculator.jsx
+++ b/src/pages/BusinessLoanCalculator.jsx
@@ -13,6 +13,7 @@ import {
 import { PoundSterling, Calculator, Building2, Calendar, TrendingUp } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const businessLoanFAQs = [
   {
@@ -108,9 +109,9 @@ export default function BusinessLoanCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Business Loan Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate monthly payments and total costs for business loans, including the tax
               benefits of interest deductibility.

--- a/src/pages/BuyToLetMortgageCalculator.jsx
+++ b/src/pages/BuyToLetMortgageCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Building, Percent } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const btlFAQs = [
   {
@@ -96,9 +97,9 @@ export default function BuyToLetMortgageCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Buy-to-Let Mortgage &amp; Rental Yield Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Analyse the profitability and viability of a UK property investment. Calculate rental
               yield, monthly profit, and key lender metrics like ICR.

--- a/src/pages/CapitalGainsTaxCalculator.jsx
+++ b/src/pages/CapitalGainsTaxCalculator.jsx
@@ -13,6 +13,7 @@ import {
 import { PoundSterling, Calculator, TrendingUp, User } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const CGT_ANNUAL_EXEMPTION = 3000; // For 2024/25 tax year
 
@@ -120,9 +121,9 @@ export default function CapitalGainsTaxCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Capital Gains Tax Calculator (UK)
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Estimate your Capital Gains Tax (CGT) bill when selling assets like property, shares,
               or cryptocurrency.

--- a/src/pages/CarCostCalculator.jsx
+++ b/src/pages/CarCostCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Car, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function CarCostCalculator() {
   const [price, setPrice] = useState('');
@@ -40,7 +41,7 @@ export default function CarCostCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Total Car Cost Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Total Car Cost Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/CarLoanCalculator.jsx
+++ b/src/pages/CarLoanCalculator.jsx
@@ -8,6 +8,7 @@ import { PoundSterling, Calculator, Car, Percent, Calendar } from 'lucide-react'
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import {
+import Heading from '@/components/common/Heading';
   PieChart,
   Pie,
   Cell,
@@ -106,9 +107,9 @@ export default function CarLoanCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Car Loan &amp; Finance Calculator UK
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Work out your monthly payments and total interest for HP &amp; PCP car finance deals.
             </p>

--- a/src/pages/ChildBenefitCalculator.jsx
+++ b/src/pages/ChildBenefitCalculator.jsx
@@ -11,6 +11,7 @@ import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import AnimatedNumber from '../components/general/AnimatedNumber';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 const FIRST_CHILD_WEEKLY = 25.6;
 const ADDITIONAL_CHILD_WEEKLY = 16.95;
@@ -162,9 +163,9 @@ export default function ChildBenefitCalculator() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <Breadcrumbs path={breadcrumbPath} />
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-blue-900 dark:text-blue-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-blue-900 dark:text-blue-100 mb-4">
               UK Child Benefit Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-blue-800/80 dark:text-blue-100/80 max-w-3xl mx-auto">
               Enter your family size and household incomes to see how much Child Benefit you can
               claim and whether the High Income Charge will claw it back.

--- a/src/pages/ChildcareCostCalculator.jsx
+++ b/src/pages/ChildcareCostCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Baby, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function ChildcareCostCalculator() {
   const [cost, setCost] = useState('');
@@ -27,7 +28,7 @@ export default function ChildcareCostCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Childcare Cost Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Childcare Cost Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/CommissionCalculator.jsx
+++ b/src/pages/CommissionCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Percent, Calculator, TrendingUp } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const commissionFAQs = [
   {
@@ -57,9 +58,9 @@ export default function CommissionCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Commission Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Quickly calculate your commission earnings based on sales revenue and commission rate.
             </p>

--- a/src/pages/CommuteCostCalculator.jsx
+++ b/src/pages/CommuteCostCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Car, Train, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function CommuteCostCalculator() {
   const [distance, setDistance] = useState('');
@@ -38,7 +39,7 @@ export default function CommuteCostCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Commute Cost Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Commute Cost Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/CompoundInterestCalculator.jsx
+++ b/src/pages/CompoundInterestCalculator.jsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/select';
 import { PoundSterling, Calculator, TrendingUp, Percent } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 export default function CompoundInterestCalculator() {
   const [principal, setPrincipal] = useState('');
@@ -87,9 +88,9 @@ export default function CompoundInterestCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Compound Interest Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               "Compound interest is the eighth wonder of the world" - Einstein. Discover the magic
               of time and compounding.

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -6,6 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Send, Loader2, CheckCircle } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 // We are removing the base44 SendEmail integration as it won't work on a static site.
 // import { SendEmail } from "@/api/integrations";
@@ -73,9 +74,9 @@ export default function Contact() {
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <Send className="w-12 h-12 mx-auto text-blue-600" />
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mt-4">
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mt-4">
             Contact Us
-          </h1>
+          </Heading>
           <p className="text-lg text-gray-600 dark:text-gray-300 mt-2">
             Have a question, feedback, or a suggestion? We'd love to hear from you.
           </p>

--- a/src/pages/ContractorCalculator.jsx
+++ b/src/pages/ContractorCalculator.jsx
@@ -21,6 +21,7 @@ import {
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import AnimatedNumber from '../components/general/AnimatedNumber';
+import Heading from '@/components/common/Heading';
 
 const contractorFAQs = [
   {
@@ -247,9 +248,9 @@ export default function ContractorCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Contractor Calculator (IR35) 2025/26
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Compare your take-home pay for contracts inside and outside IR35. Understand the tax
               implications of being a deemed employee vs. a limited company director.

--- a/src/pages/CookiePolicy.jsx
+++ b/src/pages/CookiePolicy.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Cookie } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function CookiePolicy() {
   return (
@@ -8,7 +9,7 @@ export default function CookiePolicy() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <Cookie className="w-12 h-12 mx-auto text-blue-600" />
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mt-4">Cookie Policy</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mt-4">Cookie Policy</Heading>
           <p className="text-lg text-gray-600 mt-2">Last updated: 27/08/2025</p>
         </div>
 

--- a/src/pages/CorporationTaxCalculator.jsx
+++ b/src/pages/CorporationTaxCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Building2 } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const corpTaxFAQs = [
   {
@@ -93,9 +94,9 @@ export default function CorporationTaxCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Corporation Tax Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate the Corporation Tax liability for a UK limited company based on its annual
               profits.

--- a/src/pages/CostOfLiving.jsx
+++ b/src/pages/CostOfLiving.jsx
@@ -4,6 +4,7 @@ import { createPageUrl } from '@/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ukCities, createSlug } from '../components/data/seo-data';
 import { MapPin, Users, TrendingUp } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function CostOfLiving() {
   const regions = [...new Set(ukCities.map((city) => city.region))];
@@ -14,9 +15,9 @@ export default function CostOfLiving() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Cost of Living Explorer
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Compare rental costs, population, and other key stats for major cities across the
               United Kingdom.

--- a/src/pages/CouncilTaxCalculator.jsx
+++ b/src/pages/CouncilTaxCalculator.jsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'; // Added Button import
 import { Home } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const councilTaxFAQs = [
   {
@@ -65,7 +66,7 @@ export default function CouncilTaxCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Council Tax Estimator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Council Tax Estimator</Heading>
           {/* Added description paragraph */}
           <p className="text-center text-gray-600 mt-2">
             Get an estimate for your annual council tax bill based on your property band in England.

--- a/src/pages/CreditCardRepaymentCalculator.jsx
+++ b/src/pages/CreditCardRepaymentCalculator.jsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const ccRepaymentFAQs = [
   {
@@ -122,9 +123,9 @@ export default function CreditCardRepaymentCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Credit Card Repayment Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               See how long it will take to pay off your credit card debt and how much interest
               you'll pay. Create a plan to become debt-free faster.

--- a/src/pages/CurrencyConverter.jsx
+++ b/src/pages/CurrencyConverter.jsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { ArrowRightLeft, Loader2, AlertCircle, TrendingUp, Info } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
 import AnimatedNumber from '../components/general/AnimatedNumber';
+import Heading from '@/components/common/Heading';
 
 // ----------------- Config -----------------
 const BASE = 'GBP';
@@ -203,9 +204,9 @@ export default function CurrencyConverter() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Live Currency Converter
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Check the latest foreign exchange rates for major currencies against the Pound.
             </p>

--- a/src/pages/DebtCalculator.jsx
+++ b/src/pages/DebtCalculator.jsx
@@ -25,6 +25,7 @@ import {
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators'; // NEW IMPORT
+import Heading from '@/components/common/Heading';
 
 const debtCalculatorFAQs = [
   {
@@ -300,9 +301,9 @@ export default function DebtCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
               UK Debt Repayment Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
               The best way out is always through. Create a clear debt-free plan and see how much
               interest you can save with a focused strategy.

--- a/src/pages/DebtToIncomeRatioCalculator.jsx
+++ b/src/pages/DebtToIncomeRatioCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, TrendingDown, Plus, Trash2, Percent } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const dtiFAQs = [
   {
@@ -89,9 +90,9 @@ export default function DebtToIncomeRatioCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Debt-to-Income (DTI) Ratio Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Understand a key metric lenders use to assess your financial health before approving
               you for a loan or mortgage.

--- a/src/pages/Disclaimer.jsx
+++ b/src/pages/Disclaimer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertTriangle } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function Disclaimer() {
   return (
@@ -8,7 +9,7 @@ export default function Disclaimer() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <AlertTriangle className="w-12 h-12 mx-auto text-amber-500" />
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mt-4">Disclaimer</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mt-4">Disclaimer</Heading>
           <p className="text-lg text-gray-600 mt-2">Last updated: 27/08/2025</p>
         </div>
 

--- a/src/pages/DividendTaxCalculator.jsx
+++ b/src/pages/DividendTaxCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PoundSterling, Percent, Calculator, TrendingUp } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const dividendTaxFAQs = [
   {
@@ -122,9 +123,9 @@ export default function DividendTaxCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               UK Dividend Tax Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Estimate the tax you'll owe on your dividend income for the 2024/25 tax year.
             </p>

--- a/src/pages/DreamLifestyleCalculator.jsx
+++ b/src/pages/DreamLifestyleCalculator.jsx
@@ -20,6 +20,7 @@ import {
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 const dreamItems = {
   property: {
@@ -286,9 +287,9 @@ export default function DreamLifestyleCalculator() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
             <Sparkles className="w-12 h-12 mx-auto text-purple-600 mb-4" />
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Dream Lifestyle Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Go on, live a little in your imagination! Build your fantasy empire and see just how
               wealthy your dreams really are.

--- a/src/pages/EffectiveTaxRateCalculator.jsx
+++ b/src/pages/EffectiveTaxRateCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Percent, PieChart } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const effectiveTaxRateFAQs = [
   {
@@ -106,9 +107,9 @@ export default function EffectiveTaxRateCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Effective Tax Rate Calculator UK
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Find out your true tax burden by calculating the average tax rate you pay on your
               total income.

--- a/src/pages/EmergencyFundCalculator.jsx
+++ b/src/pages/EmergencyFundCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, ShieldCheck } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function EmergencyFundCalculator() {
   const [monthlyExpenses, setMonthlyExpenses] = useState('');
@@ -35,9 +36,9 @@ export default function EmergencyFundCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Emergency Fund Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Life is unpredictable. A financial safety net provides peace of mind when you need it
               most.

--- a/src/pages/EnergyBillCalculator.jsx
+++ b/src/pages/EnergyBillCalculator.jsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Zap, Calculator, Home, TrendingUp, TrendingDown, AlertCircle } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 // Current Ofgem price cap rates (as of 2025)
 const energyRates = {
@@ -139,9 +140,9 @@ export default function EnergyBillCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Energy Bill Calculator 2025
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your annual electricity and gas costs based on current Ofgem price cap
               rates. Get accurate estimates for your household energy bills.

--- a/src/pages/FIRECalculator.jsx
+++ b/src/pages/FIRECalculator.jsx
@@ -27,6 +27,7 @@ import {
 } from 'recharts';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const fireCalculatorFAQs = [
   {
@@ -259,9 +260,9 @@ export default function FIRECalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               🔥 UK FIRE Calculator | Financial Independence Retire Early
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your path to Financial Independence and Early Retirement. Discover when you
               can retire, how much you need to save, and different FIRE scenarios for your

--- a/src/pages/FirstTimeBuyerCalculator.jsx
+++ b/src/pages/FirstTimeBuyerCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Home, User, Percent, Calculator } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const ftbFAQs = [
   {
@@ -78,7 +79,7 @@ export default function FirstTimeBuyerCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">First-Time Buyer Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">First-Time Buyer Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/FreelancerDayRateCalculator.jsx
+++ b/src/pages/FreelancerDayRateCalculator.jsx
@@ -13,6 +13,7 @@ import {
 import { PoundSterling, Calculator, Briefcase, Calendar } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const freelancerFAQs = [
   {
@@ -100,9 +101,9 @@ export default function FreelancerDayRateCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Freelancer Day Rate Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate the optimal day rate for your freelance work, factoring in taxes, expenses,
               and desired take-home income.

--- a/src/pages/FutureValueCalculator.jsx
+++ b/src/pages/FutureValueCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PoundSterling, Percent, Calendar, TrendingUp } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const fvFAQs = [
   {
@@ -54,9 +55,9 @@ export default function FutureValueCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Future Value Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Calculate the future value of a single sum investment with compound interest.
             </p>

--- a/src/pages/GrossToNetCalculator.jsx
+++ b/src/pages/GrossToNetCalculator.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators'; // Added import
+import Heading from '@/components/common/Heading';
 
 export default function GrossToNetCalculator() {
   const origin =
@@ -62,9 +63,9 @@ export default function GrossToNetCalculator() {
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
               Gross to Net Income Calculator (UK)
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto mt-3">
               Convert gross salary to net take‑home pay with UK tax and NI for 2025/26.
             </p>

--- a/src/pages/HolidayPayCalculator.jsx
+++ b/src/pages/HolidayPayCalculator.jsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 const STATUTORY_WEEKS = 5.6;
 
@@ -80,9 +81,9 @@ export default function HolidayPayCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Holiday Pay & Entitlement Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Everyone needs a break. Make sure you're getting the paid time off you're entitled to.
             </p>

--- a/src/pages/HomeEquityLoanCalculator.jsx
+++ b/src/pages/HomeEquityLoanCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Home, Banknote, Percent } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const homeEquityFAQs = [
   {
@@ -65,9 +66,9 @@ export default function HomeEquityLoanCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Home Equity Loan Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Estimate how much you could potentially borrow against the equity in your home.
             </p>

--- a/src/pages/HomeLoanMortgageCalculator.jsx
+++ b/src/pages/HomeLoanMortgageCalculator.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function HomeLoanMortgageCalculator() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -47,9 +48,9 @@ export default function HomeLoanMortgageCalculator() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
             Home Loan Mortgage Calculator
-          </h1>
+          </Heading>
           <p className="text-gray-600 mt-2">
             Quickly estimate payments for common mortgage scenarios.
           </p>

--- a/src/pages/HourlyToAnnualSalaryCalculator.jsx
+++ b/src/pages/HourlyToAnnualSalaryCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, ArrowRightLeft, Calendar, Clock } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function HourlyToAnnualSalaryCalculator() {
   const [hourlyRate, setHourlyRate] = useState('');
@@ -39,9 +40,9 @@ export default function HourlyToAnnualSalaryCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Hourly to Annual Salary Converter
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Quickly convert your hourly wage into weekly, monthly, and annual gross salary
               figures.

--- a/src/pages/HouseholdBillsSplitter.jsx
+++ b/src/pages/HouseholdBillsSplitter.jsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Plus, Trash2, Users } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function HouseholdBillsSplitter() {
   const [bills, setBills] = useState([
@@ -30,7 +31,7 @@ export default function HouseholdBillsSplitter() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Household Bills Splitter</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Household Bills Splitter</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/ISACalculator.jsx
+++ b/src/pages/ISACalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Calendar, TrendingUp } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const isaFAQs = [
   {
@@ -85,9 +86,9 @@ export default function ISACalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               ISA Savings Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               See how your savings could grow in a tax-free ISA. Project your future balance based
               on your contributions and expected returns.

--- a/src/pages/IncomeTaxCalculator.jsx
+++ b/src/pages/IncomeTaxCalculator.jsx
@@ -10,6 +10,7 @@ import CalculatorWrapper from '../components/calculators/CalculatorWrapper';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import Breadcrumbs from '../components/general/Breadcrumbs'; // Added import for Breadcrumbs
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 // Site-wide SEO (JSON-LD) definition for the page
 const incomeTaxJsonLd = {
@@ -231,9 +232,9 @@ export default function IncomeTaxCalculator() {
             {/* Breadcrumbs added here */}
             <Breadcrumbs path={breadcrumbPath} />
             <div className="text-center">
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+              <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
                 UK Income Tax Calculator 2025/26
-              </h1>
+              </Heading>
               <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
                 Demystify your tax bill. See exactly how your income is taxed across the different
                 UK tax bands for the 2025/26 financial year.

--- a/src/pages/InflationCalculator.jsx
+++ b/src/pages/InflationCalculator.jsx
@@ -10,6 +10,7 @@ import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import AnimatedNumber from '../components/general/AnimatedNumber';
 import Breadcrumbs from '../components/general/Breadcrumbs';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 // Simplified historical inflation data (CPI index, rebased to 2015=100)
 // In a real app, this would come from an API or a more extensive dataset.
@@ -100,9 +101,9 @@ export default function InflationCalculator() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <Breadcrumbs path={breadcrumbPath} />
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Inflation Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Discover the changing value of the pound over time. See how inflation affects
               purchasing power between different years.

--- a/src/pages/InheritanceTaxCalculator.jsx
+++ b/src/pages/InheritanceTaxCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { PoundSterling, Shield } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const iFAQs = [
   {
@@ -59,7 +60,7 @@ export default function InheritanceTaxCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Inheritance Tax Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Inheritance Tax Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/InvestmentCalculator.jsx
+++ b/src/pages/InvestmentCalculator.jsx
@@ -15,6 +15,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const investmentFAQs = [
   {
@@ -109,9 +110,9 @@ export default function InvestmentCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Investment &amp; Savings Growth Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Visualise the power of compound growth. Project the future value of your investments
               with regular contributions.

--- a/src/pages/JobSalaries.jsx
+++ b/src/pages/JobSalaries.jsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { jobTitles, createSlug } from '../components/data/seo-data';
 import { Briefcase, Search, PoundSterling } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function JobSalaries() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -20,9 +21,9 @@ export default function JobSalaries() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Job Salary Explorer
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Discover average salaries for hundreds of jobs across the UK. Find out what you could
               be earning.

--- a/src/pages/JobSalaryPage.jsx
+++ b/src/pages/JobSalaryPage.jsx
@@ -5,6 +5,7 @@ import { useSeo } from '@/components/seo/SeoContext';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { jobTitles, createSlug } from '../components/data/seo-data';
+import Heading from '@/components/common/Heading';
 
 export default function JobSalaryPage() {
   const { slug } = useParams();
@@ -147,9 +148,9 @@ export default function JobSalaryPage() {
                 Updated for the latest UK market data
               </span>
             </div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-3">
               {roleTitle} salary (UK)
-            </h1>
+            </Heading>
             {selectedRole.description && (
               <p className="text-lg text-gray-700 dark:text-gray-300 max-w-3xl">
                 {selectedRole.description}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -22,6 +22,7 @@ import { pageSeo, defaultOgImage, defaultOgAlt } from '../components/data/pageSe
 import CalculatorIndex from '../components/general/CalculatorIndex';
 import SeoHead from '@/components/seo/SeoHead';
 import { SeoProvider } from '@/components/seo/SeoContext';
+import Heading from '@/components/common/Heading';
 
 const COST_OF_LIVING_BASE_PATH = createPageUrl('CostOfLiving');
 
@@ -578,9 +579,9 @@ export default function Layout({ children, currentPageName }) {
         {needsFallbackH1 && fallbackH1Pages.has(currentPageName) && (
           <div className="non-printable border-b border-border bg-card">
             <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-              <h1 className="text-3xl font-bold text-foreground md:text-4xl">
+              <Heading as="h1" size="h1" weight="bold" className="text-foreground">
                 {getFallbackH1Text()}
-              </h1>
+              </Heading>
             </div>
           </div>
         )}

--- a/src/pages/LinkToUs.jsx
+++ b/src/pages/LinkToUs.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Heading from '@/components/common/Heading';
 
 // Optimized SVG representation of the Pound icon to replace the 194 KiB PNG.
 // This is embedded directly in the HTML snippet, eliminating the network request.
@@ -29,7 +30,7 @@ export default function LinkToUs() {
       <div className="bg-gray-50 border-b border-gray-200">
                {' '}
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-                    <h1 className="text-3xl md:text-4xl font-bold text-gray-900">Link to Us</h1>   
+                    <Heading as="h1" size="h1" weight="bold" className="text-gray-900">Link to Us</Heading>   
                {' '}
           <p className="text-lg text-gray-600 mt-2">
                         Support our free UK calculators by adding a badge to your site.        

--- a/src/pages/LoanComparisonCalculator.jsx
+++ b/src/pages/LoanComparisonCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Banknote, Repeat, CheckCircle2, XCircle } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const loanComparisonFAQs = [
   {
@@ -99,9 +100,9 @@ export default function LoanComparisonCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Loan Comparison Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Compare two loan offers side-by-side to see which one is truly the better deal for
               you.

--- a/src/pages/LoanRepaymentCalculator.jsx
+++ b/src/pages/LoanRepaymentCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Calendar, Percent } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const loanFAQs = [
   {
@@ -78,9 +79,9 @@ export default function LoanRepaymentCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Personal Loan Repayment Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your monthly payments and the total interest you'll pay on a personal loan.
             </p>

--- a/src/pages/MaternityPayCalculator.jsx
+++ b/src/pages/MaternityPayCalculator.jsx
@@ -10,6 +10,7 @@ import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import AnimatedNumber from '../components/general/AnimatedNumber';
 import Breadcrumbs from '../components/general/Breadcrumbs';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 const SMP_WEEKS_90_PERCENT = 6;
 const SMP_WEEKS_FLAT_RATE = 33;
@@ -84,9 +85,9 @@ export default function MaternityPayCalculator() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <Breadcrumbs path={breadcrumbPath} />
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Statutory Maternity Pay (SMP) Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Planning for a new arrival? Estimate your statutory maternity pay to help you budget
               during your maternity leave.

--- a/src/pages/Methodology.jsx
+++ b/src/pages/Methodology.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import Heading from '@/components/common/Heading';
 
 export default function Methodology() {
   const LAST_UPDATED_ISO = '2025-09-10';
@@ -22,9 +23,9 @@ export default function Methodology() {
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
               Our Methodology & Data Sources
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto mt-3">
               How we calculate UK salary, tax and mortgage results. Data sources: HMRC 2025/26, Bank
               of England.

--- a/src/pages/MinimumWageCalculator.jsx
+++ b/src/pages/MinimumWageCalculator.jsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { PoundSterling, Calculator, Scale, AlertCircle, CheckCircle } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 // Rates for 2024/2025 - check gov.uk for latest figures
 const wageRates = {
@@ -77,9 +78,9 @@ export default function MinimumWageCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               UK Minimum Wage Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Are you being paid correctly? Check your wage against the UK's National Minimum Wage
               and National Living Wage rates.

--- a/src/pages/MortgageAffordabilityCalculator.jsx
+++ b/src/pages/MortgageAffordabilityCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Users, Home, TrendingDown } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const affordabilityFAQs = [
   {
@@ -92,9 +93,9 @@ export default function MortgageAffordabilityCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Mortgage Affordability Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Get a realistic estimate of how much you could borrow for a mortgage based on your
               income and outgoings.

--- a/src/pages/MortgageCalculator.jsx
+++ b/src/pages/MortgageCalculator.jsx
@@ -18,6 +18,7 @@ import CalculatorWrapper from '../components/calculators/CalculatorWrapper';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import Breadcrumbs from '../components/general/Breadcrumbs';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 const mortgageCalculatorJsonLd = {
   '@context': 'https://schema.org',
@@ -226,9 +227,9 @@ export default function MortgageCalculator() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <Breadcrumbs path={breadcrumbPath} />
             <div className="text-center">
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+              <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
                 UK Mortgage Calculator
-              </h1>
+              </Heading>
               <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
                 Calculate UK mortgage payments, affordability, and stamp duty costs. Free mortgage
                 calculator for England, Wales, Scotland & Northern Ireland property purchases.

--- a/src/pages/MortgageCalculatorUK.jsx
+++ b/src/pages/MortgageCalculatorUK.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { Card, CardContent } from '@/components/ui/card';
+import Heading from '@/components/common/Heading';
 
 export default function MortgageCalculatorUK() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -47,9 +48,9 @@ export default function MortgageCalculatorUK() {
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
               UK Mortgage Calculators Hub
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto mt-3">
               Explore UK mortgage tools: repayment, comparison, and home loan calculators.
             </p>

--- a/src/pages/MortgageComparison.jsx
+++ b/src/pages/MortgageComparison.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function MortgageComparison() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -47,9 +48,9 @@ export default function MortgageComparison() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
             Mortgage Comparison Calculator
-          </h1>
+          </Heading>
           <p className="text-gray-600 mt-2">Compare two mortgage deals and see the total cost.</p>
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             <Link

--- a/src/pages/MortgageLoanRepayment.jsx
+++ b/src/pages/MortgageLoanRepayment.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function MortgageLoanRepayment() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -47,9 +48,9 @@ export default function MortgageLoanRepayment() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
             Mortgage Loan Repayment Calculator
-          </h1>
+          </Heading>
           <p className="text-gray-600 mt-2">Estimate your monthly repayments and total interest.</p>
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             <Link

--- a/src/pages/MortgageRepaymentCalculator.jsx
+++ b/src/pages/MortgageRepaymentCalculator.jsx
@@ -6,6 +6,7 @@ import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Calculator, Home } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import {
+import Heading from '@/components/common/Heading';
   AreaChart,
   Area,
   XAxis,
@@ -95,7 +96,7 @@ export default function MortgageRepaymentCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Mortgage Repayment Schedule Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Mortgage Repayment Schedule Calculator</Heading>
         </div>
       </div>
       <div className="max-w-7xl mx-auto p-4 py-8">

--- a/src/pages/NationalInsuranceCalculator.jsx
+++ b/src/pages/NationalInsuranceCalculator.jsx
@@ -11,6 +11,7 @@ import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import AnimatedNumber from '../components/general/AnimatedNumber';
 import Breadcrumbs from '../components/general/Breadcrumbs';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 const niThresholds = {
   '2025-26': {
@@ -127,9 +128,9 @@ export default function NationalInsuranceCalculator() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <Breadcrumbs path={breadcrumbPath} />
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK National Insurance Calculator 2025/26
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Estimate your employee National Insurance contributions for the 2025/26 tax year. See
               exactly how much you'll pay based on your gross salary.

--- a/src/pages/NetIncomeUKCalculator.jsx
+++ b/src/pages/NetIncomeUKCalculator.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function NetIncomeUKCalculator() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -47,7 +48,7 @@ export default function NetIncomeUKCalculator() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">Net Income Calculator UK</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">Net Income Calculator UK</Heading>
           <p className="text-gray-600 mt-2">Estimate your take-home pay after tax & NI.</p>
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             <Link

--- a/src/pages/NetWorthCalculator.jsx
+++ b/src/pages/NetWorthCalculator.jsx
@@ -15,6 +15,7 @@ import {
   Banknote,
 } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 const defaultAssets = [
   { name: 'Primary Property', amount: '', category: 'property' },
@@ -136,9 +137,9 @@ export default function NetWorthCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Net Worth Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Your net worth is your financial scorecard. Calculate the difference between what you
               own and what you owe.

--- a/src/pages/OvertimeBonusCalculator.jsx
+++ b/src/pages/OvertimeBonusCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, TrendingUp, Wallet, ArrowRight } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 // Simplified tax/NI calculation, should be replaced with a robust shared function in a real app
 const calculateTakeHome = (salary) => {
@@ -67,9 +68,9 @@ export default function OvertimeBonusCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Overtime & Bonus Tax Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Worked extra hours or got a bonus? Find out how much you'll actually take home after
               tax and NI.

--- a/src/pages/OvertimePayCalculator.jsx
+++ b/src/pages/OvertimePayCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PoundSterling, Clock, TrendingUp } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const overtimeFAQs = [
   {
@@ -58,9 +59,9 @@ export default function OvertimePayCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Overtime Pay Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Calculate your total gross pay including standard hours and overtime earnings.
             </p>

--- a/src/pages/OvertimeRateCalculator.jsx
+++ b/src/pages/OvertimeRateCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Percent, PoundSterling, Calculator } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const overtimeRateFAQs = [
   {
@@ -50,9 +51,9 @@ export default function OvertimeRateCalculator() {
       <div className="bg-gray-50 border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Overtime Rate Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Determine your specific hourly pay rate for working overtime hours.
             </p>

--- a/src/pages/PAYECalculator.jsx
+++ b/src/pages/PAYECalculator.jsx
@@ -20,6 +20,7 @@ import { createPageUrl } from '@/utils/createPageUrl';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 /* ==========================
    DATA (2025/26)
@@ -250,9 +251,9 @@ export default function PAYECalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               PAYE Tax &amp; National Insurance Calculator (2025/26)
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your take-home pay after income tax and National Insurance using the latest
               UK rates for England, Wales, Northern Ireland and Scotland.

--- a/src/pages/PayrollCalculator.jsx
+++ b/src/pages/PayrollCalculator.jsx
@@ -7,6 +7,7 @@ import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Calculator, Building2, User, Percent, Shield } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const payrollFAQs = [
   {
@@ -190,9 +191,9 @@ export default function PayrollCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Payroll Calculator for Employers
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Estimate the total cost of hiring an employee and see a breakdown of their take-home
               pay. Updated for 2025/26 tax year.

--- a/src/pages/PensionCalculator.jsx
+++ b/src/pages/PensionCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Shield, TrendingUp } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 export default function PensionCalculator() {
   const [currentAge, setCurrentAge] = useState('');
@@ -97,9 +98,9 @@ export default function PensionCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               UK Pension Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               The best time to plant a tree was 20 years ago. The second best time is now. Start
               planning your retirement today.

--- a/src/pages/PensionContributionCalculator.jsx
+++ b/src/pages/PensionContributionCalculator.jsx
@@ -13,6 +13,7 @@ import {
 import { PoundSterling, Calculator, Shield, TrendingUp } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const pensionFAQs = [
   {
@@ -121,9 +122,9 @@ export default function PensionContributionCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Pension Contribution Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your pension contributions, tax relief, and the real cost of building your
               retirement savings.

--- a/src/pages/PersonalLoanCalculator.jsx
+++ b/src/pages/PersonalLoanCalculator.jsx
@@ -8,6 +8,7 @@ import { PoundSterling, Calculator, Percent, Calendar } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import {
+import Heading from '@/components/common/Heading';
   LineChart,
   Line,
   XAxis,
@@ -120,9 +121,9 @@ export default function PersonalLoanCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Personal Loan Calculator UK
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your monthly payments, total interest, and see a full repayment schedule for
               any personal loan.

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ShieldCheck } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function PrivacyPolicy() {
   return (
@@ -8,7 +9,7 @@ export default function PrivacyPolicy() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <ShieldCheck className="w-12 h-12 mx-auto text-blue-600" />
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mt-4">Privacy Policy</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mt-4">Privacy Policy</Heading>
           <p className="text-lg text-gray-600 mt-2">Last updated: 27/08/2025</p>
         </div>
 

--- a/src/pages/ProRataSalaryCalculator.jsx
+++ b/src/pages/ProRataSalaryCalculator.jsx
@@ -9,6 +9,7 @@ import FAQSection from '../components/calculators/FAQSection';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function ProRataSalaryCalculator() {
   const [fullTimeSalary, setFullTimeSalary] = useState('');
@@ -127,9 +128,9 @@ export default function ProRataSalaryCalculator() {
         <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <div className="text-center">
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+              <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-2">
                 Pro-Rata Salary Calculator (UK)
-              </h1>
+              </Heading>
               <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
                 Calculate your part-time salary based on a full-time equivalent wage. Ensure you're
                 getting paid fairly for the hours you work.

--- a/src/pages/RedundancyPayCalculator.jsx
+++ b/src/pages/RedundancyPayCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Briefcase, AlertTriangle } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 // Statutory limits for 2024/2025 - check gov.uk for latest figures
 const MAX_WEEKLY_PAY = 700;
@@ -61,9 +62,9 @@ export default function RedundancyPayCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Statutory Redundancy Pay Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               If you're facing redundancy, know your rights. Calculate your estimated statutory
               redundancy entitlement.

--- a/src/pages/RemortgageCalculator.jsx
+++ b/src/pages/RemortgageCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Repeat, ArrowRight } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const remortgageFAQs = [
   {
@@ -82,9 +83,9 @@ export default function RemortgageCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Remortgage &amp; Equity Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               See how much you could save by switching to a new deal, and calculate the equity in
               your home.

--- a/src/pages/RentVsBuyCalculator.jsx
+++ b/src/pages/RentVsBuyCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Home, Key, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function RentVsBuyCalculator() {
   const [monthlyRent, setMonthlyRent] = useState('');
@@ -41,7 +42,7 @@ export default function RentVsBuyCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Rent vs. Buy Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Rent vs. Buy Calculator</Heading>
         </div>
       </div>
       <div className="max-w-7xl mx-auto p-4 py-8">

--- a/src/pages/RentalIncomeCalculator.jsx
+++ b/src/pages/RentalIncomeCalculator.jsx
@@ -15,6 +15,7 @@ import {
 import ExportActions from '../components/calculators/ExportActions';
 import { TooltipProvider } from '@/components/ui/tooltip'; // New import for TooltipProvider
 import {
+import Heading from '@/components/common/Heading';
   Accordion,
   AccordionContent,
   AccordionItem,
@@ -265,9 +266,9 @@ export default function RentalIncomeCalculator() {
           <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
               <div className="text-center">
-                <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+                <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
                   UK Rental Income Calculator 2025/26
-                </h1>
+                </Heading>
                 <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
                   Calculate your rental property profit, tax obligations, and rental yield. Free
                   calculator for UK landlords and property investors.

--- a/src/pages/RentalYieldCalculator.jsx
+++ b/src/pages/RentalYieldCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Building, Calculator, PiggyBank, TrendingUp, TrendingDown, Percent } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 const rentalYieldCalculatorJsonLd = {
   '@context': 'https://schema.org',
@@ -157,7 +158,7 @@ export default function RentalYieldCalculator() {
             <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-700 mb-4">
               <Percent className="w-4 h-4 mr-1" /> Rental Investment Tool
             </span>
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Rental Yield Calculator</h1>
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">Rental Yield Calculator</Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Work out gross and net rental yields, monthly cash flow and the cash-on-cash return for your buy-to-let property.
               Enter your rent, costs and investment details to see whether the numbers stack up.

--- a/src/pages/Resources.jsx
+++ b/src/pages/Resources.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Link2, Book, Landmark, Banknote } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 const governmentResources = [
   {
@@ -54,7 +55,7 @@ export default function Resources() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <Book className="w-12 h-12 mx-auto text-blue-600" />
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mt-4">Financial Resources</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mt-4">Financial Resources</Heading>
           <p className="text-lg text-gray-600 mt-2 max-w-3xl mx-auto">
             Knowledge is power. Here are some trusted resources and recommended reading to help you
             on your financial journey.

--- a/src/pages/RetirementSavingsCalculator.jsx
+++ b/src/pages/RetirementSavingsCalculator.jsx
@@ -8,6 +8,7 @@ import { PoundSterling, Calculator, Percent, Shield, Target } from 'lucide-react
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
 import {
+import Heading from '@/components/common/Heading';
   BarChart,
   Bar,
   XAxis,
@@ -134,9 +135,9 @@ export default function RetirementSavingsCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Retirement Savings Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Are you saving enough for retirement? Project your pension pot growth and see how much
               you could have when you retire.

--- a/src/pages/RuleOf72Calculator.jsx
+++ b/src/pages/RuleOf72Calculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Percent, Activity, Calculator } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const ruleOf72FAQs = [
   {
@@ -43,7 +44,7 @@ export default function RuleOf72Calculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Rule of 72 Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Rule of 72 Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/SalaryCalculatorPaycheck.jsx
+++ b/src/pages/SalaryCalculatorPaycheck.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function SalaryCalculatorPaycheck() {
   const origin =
@@ -62,7 +63,7 @@ export default function SalaryCalculatorPaycheck() {
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">Paycheck Calculator UK</h1>
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">Paycheck Calculator UK</Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto mt-3">
               Work out your UK paycheck after tax and NI. Supports weekly, fortnightly and monthly
               pay.

--- a/src/pages/SalaryCalculatorTakeHomePay.jsx
+++ b/src/pages/SalaryCalculatorTakeHomePay.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function SalaryCalculatorTakeHomePay() {
   const origin =
@@ -62,9 +63,9 @@ export default function SalaryCalculatorTakeHomePay() {
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
               UK Take-Home Pay Calculator (2025/26)
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto mt-3">
               Estimate UK take-home pay after tax, NI, pension and student loans for the 2025/26 tax
               year.

--- a/src/pages/SalaryIncreaseCalculator.jsx
+++ b/src/pages/SalaryIncreaseCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Calculator, TrendingUp, Percent, ArrowRight } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const salaryIncreaseFAQs = [
   {
@@ -63,9 +64,9 @@ export default function SalaryIncreaseCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Salary Increase Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               See how a pay rise will affect your annual and monthly income before tax.
             </p>

--- a/src/pages/SalarySacrificeCalculator.jsx
+++ b/src/pages/SalarySacrificeCalculator.jsx
@@ -12,6 +12,7 @@ import {
   Wallet,
 } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 const calculateTakeHome = (salary) => {
   // Simplified tax/NI calculation for demonstration purposes
@@ -109,9 +110,9 @@ export default function SalarySacrificeCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Salary Sacrifice Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Pay less tax and boost your pension pot. See how sacrificing a portion of your salary
               can increase your overall wealth.

--- a/src/pages/SavingsGoalCalculator.jsx
+++ b/src/pages/SavingsGoalCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Target, TrendingUp } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
+import Heading from '@/components/common/Heading';
 
 export default function SavingsGoalCalculator() {
   const [goalAmount, setGoalAmount] = useState('');
@@ -93,9 +94,9 @@ export default function SavingsGoalCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Savings Goal Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Dreams without goals are just wishes. Set a target, make a plan, and watch your
               savings grow.

--- a/src/pages/SelfAssessmentGuide.jsx
+++ b/src/pages/SelfAssessmentGuide.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 export default function SelfAssessmentGuide() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -52,7 +53,7 @@ export default function SelfAssessmentGuide() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">UK Self Assessment Guide</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">UK Self Assessment Guide</Heading>
           <p className="text-gray-600 mt-2">Deadlines, rates, allowances and tips for 2025/26.</p>
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             <Link

--- a/src/pages/SeverancePayCalculator.jsx
+++ b/src/pages/SeverancePayCalculator.jsx
@@ -11,6 +11,7 @@ import FAQSection from '../components/calculators/FAQSection';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
 import AnimatedNumber from '../components/general/AnimatedNumber';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 const MAX_WEEKLY_PAY = 700; // Statutory cap 2024/25 (England, Scotland, Wales)
 const MAX_SERVICE_YEARS = 20;
@@ -194,9 +195,9 @@ export default function SeverancePayCalculator() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <Breadcrumbs path={breadcrumbPath} />
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Severance Pay Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Model your potential payout when leaving a job. Combine statutory redundancy,
               contractual enhancements, pay in lieu of notice and unused holiday pay.

--- a/src/pages/SimpleInterestCalculator.jsx
+++ b/src/pages/SimpleInterestCalculator.jsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { PoundSterling, Calculator, TrendingUp, Percent, Calendar } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const simpleInterestFAQs = [
   {
@@ -64,9 +65,9 @@ export default function SimpleInterestCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Simple Interest Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate interest earned on a principal amount without the effect of compounding.
             </p>

--- a/src/pages/StampDutyCalculator.jsx
+++ b/src/pages/StampDutyCalculator.jsx
@@ -7,6 +7,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { PoundSterling, Calculator, Home, AlertTriangle } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const sdltFAQs = [
   {
@@ -161,9 +162,9 @@ export default function StampDutyCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               Stamp Duty Calculator (England & NI)
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate the Stamp Duty Land Tax (SDLT) for your property purchase.
             </p>

--- a/src/pages/StatutorySickPayCalculator.jsx
+++ b/src/pages/StatutorySickPayCalculator.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, Shield, AlertTriangle } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 const SSP_WEEKLY_RATE = 116.75;
 const SSP_MIN_WEEKLY_EARNINGS = 123;
@@ -49,9 +50,9 @@ export default function StatutorySickPayCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Statutory Sick Pay (SSP) Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               If you're too ill to work, you may be entitled to SSP. Check your eligibility and
               estimate your pay.

--- a/src/pages/StudentLoanCalculator.jsx
+++ b/src/pages/StudentLoanCalculator.jsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/select';
 import { PoundSterling, Calculator, User } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const loanPlans = {
   plan1: { threshold: 24990, rate: 0.09 },
@@ -90,9 +91,9 @@ export default function StudentLoanCalculator() {
       <div className="bg-gray-50 border-b border-gray-200 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 mb-4">
               Student Loan Repayment Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Understand the true cost of your education and plan your path to being loan-free.
             </p>

--- a/src/pages/StudentLoanRepaymentCalculator.jsx
+++ b/src/pages/StudentLoanRepaymentCalculator.jsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { BookOpen, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 const plans = {
   plan1: { threshold: 24990, rate: 0.09 },
@@ -44,7 +45,7 @@ export default function StudentLoanRepaymentCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Student Loan Repayment Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Student Loan Repayment Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/SubscriptionCostCalculator.jsx
+++ b/src/pages/SubscriptionCostCalculator.jsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/componen
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Plus, Trash2, Repeat, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function SubscriptionCostCalculator() {
   const [subs, setSubs] = useState([{ id: 1, name: '', amount: '' }]);
@@ -27,7 +28,7 @@ export default function SubscriptionCostCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">Subscription Cost Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">Subscription Cost Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/TaxAfterTaxCalculator.jsx
+++ b/src/pages/TaxAfterTaxCalculator.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function TaxAfterTaxCalculator() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -51,9 +52,9 @@ export default function TaxAfterTaxCalculator() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">
             Tax After Tax Calculator UK
-          </h1>
+          </Heading>
           <p className="text-gray-600 mt-2">Work out your UK tax after tax for 2025/26.</p>
           <div className="mt-4 flex flex-wrap justify-center gap-2">
             <Link

--- a/src/pages/TaxAndNICalculator.jsx
+++ b/src/pages/TaxAndNICalculator.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import RelatedCalculators from '../components/calculators/RelatedCalculators';
+import Heading from '@/components/common/Heading';
 
 export default function TaxAndNICalculator() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -47,7 +48,7 @@ export default function TaxAndNICalculator() {
 
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200 text-center py-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900">Tax + NI Calculator UK</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900">Tax + NI Calculator UK</Heading>
           <p className="text-gray-600 mt-2">
             Calculate combined UK Income Tax and National Insurance.
           </p>

--- a/src/pages/TaxCalculatorsUK.jsx
+++ b/src/pages/TaxCalculatorsUK.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { Card, CardContent } from '@/components/ui/card';
+import Heading from '@/components/common/Heading';
 
 export default function TaxCalculatorsUK() {
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -52,7 +53,7 @@ export default function TaxCalculatorsUK() {
       <div className="bg-white">
         <div className="bg-gray-50 border-b border-gray-200">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900">UK Tax Calculators Hub</h1>
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900">UK Tax Calculators Hub</Heading>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto mt-3">
               Explore UK tax tools for 2025/26: income tax after tax, tax + NI and net income
               calculators.

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { FileText } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function TermsOfService() {
   return (
@@ -8,9 +9,9 @@ export default function TermsOfService() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <FileText className="w-12 h-12 mx-auto text-blue-600" />
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mt-4">
+          <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mt-4">
             Terms of Service
-          </h1>
+          </Heading>
           <p className="text-lg text-gray-600 dark:text-gray-300 mt-2">Last updated: 27/08/2025</p>
         </div>
 

--- a/src/pages/TipCalculator.jsx
+++ b/src/pages/TipCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { HandCoins, Calculator } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 export default function TipCalculator() {
   const [bill, setBill] = useState('');
@@ -30,7 +31,7 @@ export default function TipCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-center">UK Tip Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold" className="text-center">UK Tip Calculator</Heading>
         </div>
       </div>
       <div className="max-w-4xl mx-auto p-4 py-8">

--- a/src/pages/TravelBudgetCalculator.jsx
+++ b/src/pages/TravelBudgetCalculator.jsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Plus, Trash2, Plane, Calculator } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const travelFAQs = [
   {
@@ -56,7 +57,7 @@ export default function TravelBudgetCalculator() {
     <div className="bg-white">
       <div className="bg-gray-50 border-b">
         <div className="max-w-7xl mx-auto px-4 py-12 text-center">
-          <h1 className="text-3xl font-bold">Travel &amp; Holiday Budget Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold">Travel &amp; Holiday Budget Calculator</Heading>
           <p className="text-lg text-gray-600 mt-2">
             Plan your next holiday with our easy-to-use travel budget calculator. Estimate costs for
             flights, accommodation, food, and activities.

--- a/src/pages/UKFinancialStats.jsx
+++ b/src/pages/UKFinancialStats.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { TrendingUp, TrendingDown, Percent, Home, Landmark, Zap, ExternalLink } from 'lucide-react';
+import Heading from '@/components/common/Heading';
 
 const StatCard = ({ title, value, change, description, trend, link, Icon }) => {
   const TrendIcon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : null;
@@ -48,9 +49,9 @@ export default function UKFinancialStats() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Financial Statistics Dashboard
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Track key UK economic indicators. Data is sourced directly from official channels like
               the Bank of England and the Office for National Statistics.

--- a/src/pages/UKGovernmentBudget.jsx
+++ b/src/pages/UKGovernmentBudget.jsx
@@ -26,6 +26,7 @@ import {
 } from 'recharts';
 import { Link } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
+import Heading from '@/components/common/Heading';
 
 const governmentBudget2024 = {
   // Data reflecting 2024/25 fiscal year estimates
@@ -317,10 +318,10 @@ export default function UKGovernmentBudget() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK Government Budget {selectedYear}/
               {(parseInt(selectedYear) + 1).toString().slice(-2)} | Where Your Taxes Go
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-4xl mx-auto">
               Understand how the UK government manages the nation's finances. See exactly where tax
               revenue comes from and how every pound of public money is spent.

--- a/src/pages/VATCalculator.jsx
+++ b/src/pages/VATCalculator.jsx
@@ -14,6 +14,7 @@ import {
 import { PoundSterling, Calculator, Percent } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const vatFAQs = [
   {
@@ -86,9 +87,9 @@ export default function VATCalculator() {
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700 non-printable">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               UK VAT Calculator
-            </h1>
+            </Heading>
             <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Quickly add or remove VAT from any amount. Perfect for business owners, freelancers,
               and shoppers.

--- a/src/pages/WeddingBudgetCalculator.jsx
+++ b/src/pages/WeddingBudgetCalculator.jsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { PoundSterling, Calculator, PartyPopper, Trash2 } from 'lucide-react';
 import FAQSection from '../components/calculators/FAQSection';
+import Heading from '@/components/common/Heading';
 
 const weddingFAQs = [
   {
@@ -105,7 +106,7 @@ export default function WeddingBudgetCalculator() {
     <div className="bg-white dark:bg-gray-900">
       <div className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
-          <h1 className="text-3xl md:text-4xl font-bold">Wedding Budget Calculator</h1>
+          <Heading as="h1" size="h1" weight="bold">Wedding Budget Calculator</Heading>
           <p className="text-lg text-gray-600 mt-2">
             Plan and track your wedding expenses to stay on budget.
           </p>


### PR DESCRIPTION
## Summary
- replace page-level `<h1>` tags across calculators and content screens with the shared `Heading` component while retaining contextual styling
- add the common `Heading` import to each page and drop redundant Tailwind font-size utilities
- update the layout fallback heading to use the same component for consistent typography

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e12843d77c83209ef90509d8036f21