### PR TITLE
Move Heading import to top-level in RentalIncomeCalculator

### DIFF
--- a/src/pages/RentalIncomeCalculator.jsx
+++ b/src/pages/RentalIncomeCalculator.jsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import ExportActions from '../components/calculators/ExportActions';
 import { TooltipProvider } from '@/components/ui/tooltip'; // New import for TooltipProvider
+import Heading from '@/components/common/Heading';
 import {
   Accordion,
   AccordionContent,


### PR DESCRIPTION
## Summary
- Move the Heading component import into the top-level import section of RentalIncomeCalculator so it sits before the accordion imports.

## Testing
- npm run build *(fails: RequestError ECONNREFUSED when generating critical CSS from http://localhost/)*

------
https://chatgpt.com/codex/tasks/task_e_68e129b9d94c8320901704850a39c694