### PR TITLE
Adjust heading clamp scales for calmer hero typography

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -150,7 +150,7 @@
     line-height: 1.05;
     text-wrap: balance;
     color: hsl(var(--foreground));
-    font-size: clamp(2.25rem, 1.9rem + 1vw, 3rem);
+    font-size: clamp(2rem, 1.6rem + 1vw, 2.5rem);
   }
 
   h2,
@@ -161,7 +161,7 @@
     line-height: 1.1;
     text-wrap: balance;
     color: hsl(var(--foreground));
-    font-size: clamp(2.125rem, 1.85rem + 1vw, 3rem);
+    font-size: clamp(1.85rem, 1.5rem + 0.9vw, 2.1rem);
   }
 
   h3,


### PR DESCRIPTION
## Summary
- reduce the responsive clamp range for the primary heading utility classes so H1 and H2 top out near 2.5rem and 2.1rem respectively
- confirm the Heading component continues to map size props to the updated utility classes
- manually verify the UK Salary Calculator hero and section headings across breakpoints via local preview

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173`

------
https://chatgpt.com/codex/tasks/task_e_68e12fa83148832090db3b85a228bb8f