### PR TITLE
Adjust lead typography scale

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -191,7 +191,7 @@
     letter-spacing: 0;
     line-height: 1.65;
     color: hsl(var(--foreground));
-    font-size: clamp(1.1rem, 1rem + 0.35vw, 1.35rem);
+    font-size: clamp(1.05rem, 0.95rem + 0.3vw, 1.22rem);
   }
 
   small.caption,


### PR DESCRIPTION
## Summary
- tighten the `.lead` font-size clamp so highlighted paragraphs remain complementary to body copy

## Testing
- npm run lint *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68e13f20f9148320bf70dc9686226eba