### PR TITLE
Tighten lead paragraph sizing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -189,9 +189,9 @@
     font-family: var(--font-sans);
     font-weight: 500;
     letter-spacing: 0;
-    line-height: 1.65;
+    line-height: 1.6;
     color: hsl(var(--foreground));
-    font-size: clamp(1.05rem, 0.95rem + 0.3vw, 1.22rem);
+    font-size: clamp(1rem, 0.92rem + 0.25vw, 1.2rem);
   }
 
   small.caption,


### PR DESCRIPTION
## Summary
- narrow the clamp range for lead paragraphs to keep supporting text closer to the body size while retaining emphasis
- adjust lead line-height to maintain comfortable legibility with the smaller typography

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e144dc36348320acd86e1ee7f1dab2