### PR TITLE
Handle home hash navigation

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 import { useLocation } from 'react-router-dom';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Search, Calculator, TrendingUp, Users, ExternalLink } from 'lucide-react';
@@ -50,12 +50,14 @@ const homepageFaqs = [
 ];
 
 export default function Home() {
-  const { search } = useLocation();
+  const location = useLocation();
+  const { search, hash } = location;
   const hasQuery = new URLSearchParams(search).has('q');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [showAllCalculators, setShowAllCalculators] = useState(false);
   const [pendingScrollSlug, setPendingScrollSlug] = useState(null);
+  const lastHandledHashRef = useRef(null);
   const { setSeo, resetSeo } = useSeo();
 
   const stats = getCalculatorStats();
@@ -158,6 +160,26 @@ export default function Home() {
     }
     setPendingScrollSlug(null);
   }, [showAllCalculators, pendingScrollSlug]);
+
+  useEffect(() => {
+    if (!hash) {
+      lastHandledHashRef.current = null;
+      return;
+    }
+
+    const slug = hash.replace(/^#/, '').trim();
+    if (!slug) {
+      return;
+    }
+
+    if (lastHandledHashRef.current === slug) {
+      return;
+    }
+
+    lastHandledHashRef.current = slug;
+    setShowAllCalculators(true);
+    setPendingScrollSlug(slug);
+  }, [hash]);
 
   return (
     <div className="bg-background text-foreground">


### PR DESCRIPTION
## Summary
- pull the full location object in the home page so query handling remains intact while exposing the hash
- expand the calculator directory and queue the scroll target when a hash slug is present, avoiding duplicate work for repeated slugs

## Testing
- npm run build *(fails: local critical CSS step cannot reach http://localhost/ in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14b3d6f6883209946b8fb8482e901