### PR TITLE
Rename Tax Tools hub card

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -102,7 +102,7 @@ export default function Home() {
       description: 'Calculate take-home pay, tax, and more.',
     },
     {
-      title: 'Tax Tools',
+      title: 'Tax Calculators',
       icon: PoundSterling,
       link: '#tax-calculators',
       description: 'Tools for income tax, NI, VAT, and CGT.',


### PR DESCRIPTION
## Summary
- rename the home page tax hub card to read "Tax Calculators"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e14c9a69308320846ed43ea64de4c9