### PR TITLE
Add typography stylesheet and update global import

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import '@/styles/typography.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -141,89 +143,6 @@
   }
   body {
     @apply bg-background text-foreground font-sans;
-  }
-  h1,
-  .heading-1 {
-    font-family: var(--font-sans);
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    line-height: 1.05;
-    text-wrap: balance;
-    color: hsl(var(--foreground));
-    font-size: clamp(2rem, 1.6rem + 1vw, 2.5rem);
-  }
-
-  h2,
-  .heading-2 {
-    font-family: var(--font-sans);
-    font-weight: 700;
-    letter-spacing: -0.015em;
-    line-height: 1.1;
-    text-wrap: balance;
-    color: hsl(var(--foreground));
-    font-size: clamp(1.85rem, 1.5rem + 0.9vw, 2.1rem);
-  }
-
-  h3,
-  .heading-3 {
-    font-family: var(--font-sans);
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    line-height: 1.2;
-    color: hsl(var(--foreground));
-    font-size: clamp(1.4rem, 1.25rem + 0.6vw, 1.8rem);
-  }
-
-  h4,
-  .heading-4 {
-    font-family: var(--font-sans);
-    font-weight: 600;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: hsl(var(--foreground));
-    font-size: clamp(1.25rem, 1.15rem + 0.35vw, 1.6rem);
-  }
-
-  p.lead,
-  .lead {
-    font-family: var(--font-sans);
-    font-weight: 500;
-    letter-spacing: 0;
-    line-height: 1.6;
-    color: hsl(var(--foreground));
-    font-size: clamp(1rem, 0.92rem + 0.25vw, 1.2rem);
-  }
-
-  small.caption,
-  .caption {
-    font-family: var(--font-sans);
-    font-weight: 600;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    line-height: 1.4;
-    color: hsl(var(--neutral-soft-foreground));
-    font-size: clamp(0.75rem, 0.7rem + 0.18vw, 0.88rem);
-  }
-
-  .heading-eyebrow {
-    display: block;
-    margin-bottom: 0.5rem;
-  }
-
-  .heading-underline {
-    position: relative;
-    padding-bottom: 0.75rem;
-  }
-
-  .heading-underline::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    width: clamp(3rem, 2.25rem + 3vw, 6rem);
-    height: 0.25rem;
-    border-radius: 9999px;
-    background: linear-gradient(90deg, hsl(var(--brand-teal)) 0%, hsl(var(--brand-aqua)) 100%);
   }
 }
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,121 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .heading-1,
+  h1 {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    text-wrap: balance;
+    color: hsl(var(--foreground));
+    font-size: clamp(2rem, 1.6rem + 1vw, 2.5rem);
+  }
+
+  .heading-2,
+  h2 {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    line-height: 1.1;
+    text-wrap: balance;
+    color: hsl(var(--foreground));
+    font-size: clamp(1.85rem, 1.5rem + 0.9vw, 2.1rem);
+  }
+
+  .heading-3,
+  h3 {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+    color: hsl(var(--foreground));
+    font-size: clamp(1.4rem, 1.25rem + 0.6vw, 1.8rem);
+  }
+
+  .heading-4,
+  h4 {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+    color: hsl(var(--foreground));
+    font-size: clamp(1.25rem, 1.15rem + 0.35vw, 1.6rem);
+  }
+
+  .lead,
+  p.lead {
+    font-family: var(--font-sans);
+    font-weight: 500;
+    letter-spacing: 0;
+    line-height: 1.6;
+    color: hsl(var(--foreground));
+    font-size: clamp(1rem, 0.92rem + 0.25vw, 1.2rem);
+  }
+
+  .caption,
+  small.caption {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    line-height: 1.4;
+    color: hsl(var(--neutral-soft-foreground));
+    font-size: clamp(0.75rem, 0.7rem + 0.18vw, 0.88rem);
+  }
+
+  .heading-eyebrow {
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+
+  .heading-underline {
+    position: relative;
+    padding-bottom: 0.75rem;
+  }
+
+  .heading-underline::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: clamp(3rem, 2.25rem + 3vw, 6rem);
+    height: 0.25rem;
+    border-radius: 9999px;
+    background: linear-gradient(90deg, hsl(var(--brand-teal)) 0%, hsl(var(--brand-aqua)) 100%);
+  }
+}
+
+@media print {
+  .heading-1,
+  h1 {
+    font-size: 2.5rem;
+  }
+
+  .heading-2,
+  h2 {
+    font-size: 2.1rem;
+  }
+
+  .heading-3,
+  h3 {
+    font-size: 1.8rem;
+  }
+
+  .heading-4,
+  h4 {
+    font-size: 1.6rem;
+  }
+
+  .lead,
+  p.lead {
+    font-size: 1.2rem;
+  }
+
+  .caption,
+  small.caption {
+    font-size: 0.88rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add the shared typography stylesheet with heading, lead, and caption token classes plus print overrides
- import the typography sheet from the global index.css so the token classes load once
- clean up the duplicated heading and text utility rules from index.css so typography is centralized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14ed9990883208cfbdcd3a314df31