### PR TITLE
Update bar chart legend styling

### DIFF
--- a/src/pages/SalaryCalculatorUK.jsx
+++ b/src/pages/SalaryCalculatorUK.jsx
@@ -1198,7 +1198,9 @@ export default function SalaryCalculatorUK() {
                               width={40}
                             />
                             <RechartsTooltip content={<CustomTooltip />} />
-                            <Legend wrapperStyle={{ fontSize: '14px' }} />{' '}
+                            <Legend
+                              formatter={(value) => <span className="caption">{value}</span>}
+                            />{' '}
                             {/* Apply text color to legend */}
                             <Bar dataKey="Take Home" stackId="a" fill={CHART_COLORS.takeHome} />
                             <Bar dataKey="Tax" stackId="a" fill={CHART_COLORS.tax} />


### PR DESCRIPTION
## Summary
- remove inline font styling from the salary bar chart legend
- apply the shared caption typography class through a legend formatter for consistent sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1506d54c48320a2d1bec8fa56bc73