### PR TITLE
Align typography tokens across home and calculators

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -187,7 +187,7 @@ export default function Home() {
       <div className="relative border-b border-border/70 bg-hero-surface">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <div className="text-center max-w-4xl mx-auto text-hero-foreground">
-            <Heading as="h1" size="h1" weight="bold" className="text-hero-foreground mb-4">
+            <Heading as="h1" size="h1" weight="bold" className="title-hero text-hero-foreground mb-4">
               Free UK Salary, Tax & Mortgage Calculators
             </Heading>
             <p className="lead text-muted-foreground mb-8">
@@ -224,16 +224,16 @@ export default function Home() {
                             <div className="flex items-center justify-between">
                               <div>
                                 <p className="font-medium text-foreground">{calc.name}</p>
-                                <p className="text-sm text-muted-foreground">{calc.description}</p>
+                                <p className="body text-muted-foreground">{calc.description}</p>
                                 {(calc.category || calc.subCategory) && (
-                                  <p className="text-xs text-neutral-soft-foreground">
+                                  <p className="caption text-neutral-soft-foreground">
                                     {calc.category || 'Calculator'}{' '}
                                     {calc.subCategory ? `→ ${calc.subCategory}` : ''}
                                   </p>
                                 )}
                               </div>
                               {calc.status === 'planned' ? (
-                                <Badge variant="secondary" className="text-xs">
+                                <Badge variant="secondary" className="caption">
                                   Coming Soon
                                 </Badge>
                               ) : (
@@ -250,7 +250,7 @@ export default function Home() {
             </div>
 
             {/* Quick Stats */}
-            <div className="flex flex-wrap items-center justify-center gap-4 text-sm text-muted-foreground sm:gap-8">
+            <div className="flex flex-wrap items-center justify-center gap-4 body text-muted-foreground sm:gap-8">
               <div className="flex items-center gap-2">
                 <Calculator className="h-4 w-4 text-primary" />
                 <span>{stats.total} Calculators</span>
@@ -289,13 +289,13 @@ export default function Home() {
                 </div>
                 <Heading
                   as="h3"
-                  size="h4"
+                  size="h3"
                   className="text-foreground transition-colors group-hover:text-primary"
                 >
                   {card.title}
                 </Heading>
               </div>
-              <p className="text-sm text-muted-foreground">{card.description}</p>
+              <p className="body text-muted-foreground">{card.description}</p>
             </button>
           ))}
         </div>
@@ -331,14 +331,14 @@ export default function Home() {
                 <calc.icon className="h-5 w-5 text-primary" />
                 <Heading
                   as="h3"
-                  size="h4"
+                  size="h3"
                   className="text-foreground transition-colors group-hover:text-primary"
                 >
                   {calc.name}
                 </Heading>
               </div>
-              <p className="mb-2 text-sm text-muted-foreground">{calc.description}</p>
-              <p className="text-xs text-neutral-soft-foreground">{calc.category}</p>
+              <p className="mb-2 body text-muted-foreground">{calc.description}</p>
+              <p className="caption text-neutral-soft-foreground">{calc.category}</p>
             </Link>
           ))}
         </div>
@@ -384,7 +384,7 @@ export default function Home() {
                       <Heading as="h3" size="h3" weight="bold" className="text-foreground">
                         {category.name}
                       </Heading>
-                      <p className="text-muted-foreground">{category.description}</p>
+                      <p className="body text-muted-foreground">{category.description}</p>
                     </div>
                   </div>
 
@@ -394,7 +394,7 @@ export default function Home() {
                       <div key={subCategory.name} className="space-y-3">
                         <Heading
                           as="h4"
-                          size="h4"
+                          size="h3"
                           className="border-l-4 border-primary pl-3 text-foreground"
                         >
                           {subCategory.name}
@@ -409,15 +409,15 @@ export default function Home() {
                                     to={calc.url}
                                     onMouseEnter={() => calc.page && prefetchPage(calc.page)}
                                     onFocus={() => calc.page && prefetchPage(calc.page)}
-                                    className="flex-1 text-sm font-medium text-primary transition-colors hover:text-primary/80 hover:underline"
+                                    className="flex-1 body font-medium text-primary transition-colors hover:text-primary/80 hover:underline"
                                   >
                                     {calc.name}
                                   </Link>
                                 ) : (
-                                  <span className="flex-1 text-sm text-muted-foreground/60">{calc.name}</span>
+                                  <span className="flex-1 body text-muted-foreground/60">{calc.name}</span>
                                 )}
                                 {(calc.status === 'planned' || calc.status === 'pending') && (
-                                  <Badge variant="outline" className="ml-2 text-xs text-primary">
+                                  <Badge variant="outline" className="ml-2 caption text-primary">
                                     Coming Soon
                                   </Badge>
                                 )}

--- a/src/pages/PAYECalculator.jsx
+++ b/src/pages/PAYECalculator.jsx
@@ -254,7 +254,7 @@ export default function PAYECalculator() {
             <Heading as="h1" size="h1" weight="bold" className="text-gray-900 dark:text-gray-100 mb-4">
               PAYE Tax &amp; National Insurance Calculator (2025/26)
             </Heading>
-            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            <p className="lead text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
               Calculate your take-home pay after income tax and National Insurance using the latest
               UK rates for England, Wales, Northern Ireland and Scotland.
             </p>
@@ -280,7 +280,7 @@ export default function PAYECalculator() {
           <div className="lg:col-span-2 non-printable">
             {/* Common scenarios */}
             <div className="mb-4 space-y-2">
-              <p className="text-sm text-gray-500">Try a quick scenario:</p>
+              <p className="body text-gray-500">Try a quick scenario:</p>
               <div className="flex flex-wrap gap-2">
                 {[
                   { label: 'New graduate (£28k)', salary: 28000, loc: 'england' },
@@ -347,7 +347,7 @@ export default function PAYECalculator() {
                     onChange={(e) => setTaxCode(e.target.value)}
                     placeholder="e.g. 1257L"
                   />
-                  <p className="text-xs text-gray-500">Found on your payslip or P60</p>
+                  <p className="caption text-gray-500">Found on your payslip or P60</p>
                 </div>
 
                 <div className="space-y-2">
@@ -424,7 +424,7 @@ export default function PAYECalculator() {
                     <div className="text-4xl font-bold text-green-900">
                       £{safeGBP(results.netPerPeriod)}
                     </div>
-                    <p className="text-sm text-green-700">
+                    <p className="body text-green-700">
                       Annual: £
                       {(results.netSalary ?? 0).toLocaleString('en-GB', {
                         maximumFractionDigits: 0,
@@ -447,25 +447,25 @@ export default function PAYECalculator() {
                       return (
                         <div className="grid md:grid-cols-3 gap-4">
                           <div className="p-4 bg-gray-50 rounded-lg">
-                            <p className="text-xs text-gray-500">Effective tax + NI rate</p>
+                            <p className="caption text-gray-500">Effective tax + NI rate</p>
                             <p className="text-2xl font-bold text-gray-900">
                               {safeFixed(eff * 100, 1)}%
                             </p>
-                            <p className="text-xs text-gray-500">Total deductions / gross</p>
+                            <p className="caption text-gray-500">Total deductions / gross</p>
                           </div>
                           <div className="p-4 bg-gray-50 rounded-lg">
-                            <p className="text-xs text-gray-500">Marginal tax rate</p>
+                            <p className="caption text-gray-500">Marginal tax rate</p>
                             <p className="text-2xl font-bold text-gray-900">
                               {safeFixed((taxMarginal || 0) * 100, 0)}%
                             </p>
-                            <p className="text-xs text-gray-500">On your next £1 (income tax)</p>
+                            <p className="caption text-gray-500">On your next £1 (income tax)</p>
                           </div>
                           <div className="p-4 bg-gray-50 rounded-lg">
-                            <p className="text-xs text-gray-500">Combined marginal</p>
+                            <p className="caption text-gray-500">Combined marginal</p>
                             <p className="text-2xl font-bold text-gray-900">
                               {safeFixed((combined || 0) * 100, 0)}%
                             </p>
-                            <p className="text-xs text-gray-500">Income tax + NI on next £1</p>
+                            <p className="caption text-gray-500">Income tax + NI on next £1</p>
                           </div>
                         </div>
                       );
@@ -476,7 +476,7 @@ export default function PAYECalculator() {
                 {/* Threshold callouts */}
                 {Number(String(grossSalary).replace(/[, ]+/g, '')) > 100000 && (
                   <Card className="border-amber-300 bg-amber-50">
-                    <CardContent className="p-4 text-sm text-amber-900">
+                    <CardContent className="p-4 body text-amber-900">
                       Over £100,000 your Personal Allowance is tapered. For every £2 above £100k,
                       you lose £1 of allowance until it reaches £0. That’s why your effective rate
                       rises sharply here.
@@ -485,7 +485,7 @@ export default function PAYECalculator() {
                 )}
                 {Number(String(grossSalary).replace(/[, ]+/g, '')) <= 12570 && hasCalculated && (
                   <Card className="border-blue-200 bg-blue-50">
-                    <CardContent className="p-4 text-sm text-blue-900">
+                    <CardContent className="p-4 body text-blue-900">
                       You’re within the Personal Allowance. You won’t pay income tax, but NI may
                       still apply above the NI thresholds.
                     </CardContent>
@@ -499,21 +499,21 @@ export default function PAYECalculator() {
                     </CardHeader>
                     <CardContent className="space-y-2">
                       <div className="text-center p-4 bg-red-50 rounded-lg">
-                        <p className="text-sm text-red-600">Annual Tax</p>
+                        <p className="body text-red-600">Annual Tax</p>
                         <p className="text-xl font-bold text-red-800">
                           £
                           {(results.taxAmount ?? 0).toLocaleString('en-GB', {
                             maximumFractionDigits: 0,
                           })}
                         </p>
-                        <p className="text-xs text-red-500">
+                        <p className="caption text-red-500">
                           {payFrequency}: £{safeFixed(results.taxPerPeriod)}
                         </p>
                       </div>
                       {(results.taxBreakdown ?? []).map((bracket, index) => (
                         <div
                           key={index}
-                          className="flex justify-between text-sm p-2 border-l-2 border-red-300"
+                          className="flex justify-between body p-2 border-l-2 border-red-300"
                         >
                           <span>
                             {bracket?.name} ({safeFixed(bracket?.rate, 0)}%)
@@ -530,21 +530,21 @@ export default function PAYECalculator() {
                     </CardHeader>
                     <CardContent className="space-y-2">
                       <div className="text-center p-4 bg-blue-50 rounded-lg">
-                        <p className="text-sm text-blue-600">Annual NI</p>
+                        <p className="body text-blue-600">Annual NI</p>
                         <p className="text-xl font-bold text-blue-800">
                           £
                           {(results.niAmount ?? 0).toLocaleString('en-GB', {
                             maximumFractionDigits: 0,
                           })}
                         </p>
-                        <p className="text-xs text-blue-500">
+                        <p className="caption text-blue-500">
                           {payFrequency}: £{safeFixed(results.niPerPeriod)}
                         </p>
                       </div>
                       {(results.niBreakdown ?? []).map((ni, index) => (
                         <div
                           key={index}
-                          className="flex justify-between text-sm p-2 border-l-2 border-blue-300"
+                          className="flex justify-between body p-2 border-l-2 border-blue-300"
                         >
                           <span>Class 1 NI ({safeFixed(ni?.rate, 0)}%)</span>
                           <span>£{safeFixed(ni?.amount, 0)}</span>
@@ -563,7 +563,7 @@ export default function PAYECalculator() {
                     {(() => {
                       const annualSalary = Number(String(grossSalary).replace(/[, ]+/g, '')) || 0;
                       if (!annualSalary)
-                        return <p className="text-sm text-gray-500">Enter a salary to compare.</p>;
+                        return <p className="body text-gray-500">Enter a salary to compare.</p>;
                       const rUK = calculateResults({
                         annualSalary,
                         location: 'england',
@@ -577,7 +577,7 @@ export default function PAYECalculator() {
                         payFrequency,
                       });
                       return (
-                        <table className="min-w-[520px] text-sm">
+                        <table className="min-w-[520px] body">
                           <thead>
                             <tr className="text-left border-b">
                               <th className="py-2 pr-4">Metric</th>
@@ -663,7 +663,7 @@ export default function PAYECalculator() {
             <CardHeader>
               <CardTitle>How this calculator works (2025/26)</CardTitle>
             </CardHeader>
-            <CardContent className="text-sm leading-6 text-gray-700">
+            <CardContent className="body leading-6 text-gray-700">
               <ul className="list-disc pl-5 space-y-2">
                 <li>
                   Tax year: 6 April 2025 – 5 April 2026. Bands and rates reflect the latest public

--- a/src/pages/SalaryCalculatorUK.jsx
+++ b/src/pages/SalaryCalculatorUK.jsx
@@ -412,7 +412,7 @@ const AdvancedOptions = React.memo(
           onChange={(e) => onValueChange('taxCode', e.target.value)}
           className="dark:bg-gray-700 dark:text-gray-50 dark:border-gray-600"
         />
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="caption text-gray-500 dark:text-gray-400">
           Default for {taxData[taxYear].name} is {taxData[taxYear].defaultTaxCode}
         </p>
       </div>
@@ -472,7 +472,7 @@ const AdvancedOptions = React.memo(
               className="pl-10 dark:bg-gray-700 dark:text-gray-50 dark:border-gray-600"
             />
           </div>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="caption text-gray-500 dark:text-gray-400">
             Annual investment limit: £200,000
           </p>
         </div>
@@ -490,7 +490,7 @@ const AdvancedOptions = React.memo(
               className="pl-10 dark:bg-gray-700 dark:text-gray-50 dark:border-gray-600"
             />
           </div>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="caption text-gray-500 dark:text-gray-400">
             Annual investment limit: £1,000,000
           </p>
         </div>
@@ -506,16 +506,16 @@ const AdvancedOptions = React.memo(
                 <HelpCircle className="w-4 h-4 text-gray-400 hover:text-gray-600 dark:text-gray-300 cursor-help" />
               </TooltipTrigger>
               <TooltipContent className="max-w-xs bg-gray-800 text-white p-3 rounded-lg">
-                <p className="text-sm">
+                <p className="body">
                   <strong>Common allowances include:</strong>
                 </p>
-                <ul className="text-xs mt-1 space-y-1">
+                <ul className="caption mt-1 space-y-1">
                   <li>• Marriage Allowance: £1,260</li>
                   <li>• Blind Person's Allowance: £3,070</li>
                   <li>• Property Allowance: up to £1,000</li>
                   <li>• Trading Allowance: up to £1,000</li>
                 </ul>
-                <p className="text-xs mt-2 italic">
+                <p className="caption mt-2 italic">
                   Only include if you're already entitled to these allowances.
                 </p>
               </TooltipContent>
@@ -532,7 +532,7 @@ const AdvancedOptions = React.memo(
             placeholder="e.g. 1260"
           />
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="caption text-gray-500 dark:text-gray-400">
           e.g. Marriage Allowance, Blind Person's Allowance.
           <a
             href="#faq-section"
@@ -833,7 +833,7 @@ export default function SalaryCalculatorUK() {
               maximumFractionDigits: 2,
             })}
           </p>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="caption text-gray-500 dark:text-gray-400">
             {results.grossAnnual > 0 ? ((data.value / results.grossAnnual) * 100).toFixed(1) : 0}%
             of gross salary
           </p>
@@ -857,7 +857,7 @@ export default function SalaryCalculatorUK() {
         fill="currentColor" // Use currentColor to pick up CSS text color
         textAnchor={x > cx ? 'start' : 'end'}
         dominantBaseline="central"
-        className="text-xs text-gray-800 dark:text-gray-200" // Tailwind classes for text color and size
+        className="caption text-gray-800 dark:text-gray-200" // Tailwind classes for text color and size
       >
         {`${name} ${(percent * 100).toFixed(0)}%`}
       </text>
@@ -912,7 +912,7 @@ export default function SalaryCalculatorUK() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <Breadcrumbs path={breadcrumbPath} />
             <div className="text-center">
-              <Heading as="h1" size="h1" weight="bold" className="mb-4 text-hero-foreground">
+              <Heading as="h1" size="h1" weight="bold" className="title-hero mb-4 text-hero-foreground">
                 UK Salary Calculator – Take-Home Pay 2025/26
               </Heading>
               <p className="lead text-muted-foreground max-w-3xl mx-auto">
@@ -950,7 +950,7 @@ export default function SalaryCalculatorUK() {
               </div>
 
               {/* Additional keyword-rich content */}
-              <div className="mt-6 text-sm text-muted-foreground max-w-4xl mx-auto">
+              <div className="mt-6 body text-muted-foreground max-w-4xl mx-auto">
                 <p>
                   Supports gross-to-net and net-to-gross calculations • Updated for 2025/26 tax
                   rates • Includes student loan repayments • Scottish income tax rates supported
@@ -1097,7 +1097,7 @@ export default function SalaryCalculatorUK() {
                       <CardContent className="p-6">
                         <div className="flex items-center justify-between">
                           <div>
-                            <p className="text-sm font-medium text-green-800 dark:text-green-300">
+                            <p className="body font-medium text-green-800 dark:text-green-300">
                               Annual Take-Home
                             </p>
                             <div className="text-3xl font-bold text-green-900 dark:text-green-100">
@@ -1112,7 +1112,7 @@ export default function SalaryCalculatorUK() {
                             <TrendingUp className="w-6 h-6 text-white" />
                           </div>
                         </div>
-                        <p className="text-sm text-green-700 dark:text-green-300 mt-2">
+                        <p className="body text-green-700 dark:text-green-300 mt-2">
                           £
                           {(results.takeHomeAnnual / 12)?.toLocaleString('en-GB', {
                             minimumFractionDigits: 2,
@@ -1127,7 +1127,7 @@ export default function SalaryCalculatorUK() {
                       <CardContent className="p-6">
                         <div className="flex items-center justify-between">
                           <div>
-                            <p className="text-sm font-medium text-red-800 dark:text-red-300">
+                            <p className="body font-medium text-red-800 dark:text-red-300">
                               Total Deductions
                             </p>
                             <div className="text-3xl font-bold text-red-900 dark:text-red-100">
@@ -1142,7 +1142,7 @@ export default function SalaryCalculatorUK() {
                             <TrendingDown className="w-6 h-6 text-white" />
                           </div>
                         </div>
-                        <p className="text-sm text-red-700 dark:text-red-300 mt-2">
+                        <p className="body text-red-700 dark:text-red-300 mt-2">
                           {results.grossAnnual > 0
                             ? ((results.totalDeductions / results.grossAnnual) * 100).toFixed(1)
                             : 0}
@@ -1275,7 +1275,7 @@ export default function SalaryCalculatorUK() {
                             </div>
 
                             <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
-                              <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                              <p className="body text-yellow-800 dark:text-yellow-300">
                                 💡{' '}
                                 <strong>
                                   To earn £
@@ -1296,7 +1296,7 @@ export default function SalaryCalculatorUK() {
                                   .
                                 </strong>
                               </p>
-                              <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-1">
+                              <p className="caption text-yellow-700 dark:text-yellow-400 mt-1">
                                 Here's how that gross salary breaks down:
                               </p>
                             </div>
@@ -1308,7 +1308,7 @@ export default function SalaryCalculatorUK() {
                                   3. Personal Allowance (Tax-Free)
                                 </span>
                                 {showAdvanced && (
-                                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                                  <p className="body text-gray-600 dark:text-gray-300">
                                     Tax code: {taxCode}{' '}
                                     {Number(otherAllowances) > 0
                                       ? `+ £${Number(otherAllowances).toLocaleString()} other allowances`
@@ -1349,7 +1349,7 @@ export default function SalaryCalculatorUK() {
                                   2. Personal Allowance (Tax-Free)
                                 </span>
                                 {showAdvanced && (
-                                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                                  <p className="body text-gray-600 dark:text-gray-300">
                                     Tax code: {taxCode}{' '}
                                     {Number(otherAllowances) > 0
                                       ? `+ £${Number(otherAllowances).toLocaleString()} other allowances`
@@ -1376,7 +1376,7 @@ export default function SalaryCalculatorUK() {
                                 {activeTab === 'netToGross' ? '4' : '3'}. Pension Contribution
                                 (Pre-Tax)
                               </span>
-                              <p className="text-sm text-gray-600 dark:text-gray-300">
+                              <p className="body text-gray-600 dark:text-gray-300">
                                 {pensionValue}
                                 {pensionType === 'percent' ? '%' : ' Fixed PM'}
                               </p>
@@ -1418,7 +1418,7 @@ export default function SalaryCalculatorUK() {
 
                         {/* Income Tax Breakdown */}
                         <div className="space-y-2">
-                          <Heading as="h4" size="h4" weight="medium" className="text-foreground">
+                          <Heading as="h4" size="h3" weight="medium" className="text-foreground">
                             {activeTab === 'netToGross'
                               ? showAdvanced && results.pension > 0
                                 ? '6'
@@ -1437,7 +1437,7 @@ export default function SalaryCalculatorUK() {
                                 <span className="font-medium text-gray-900 dark:text-gray-100">
                                   {bracket.name} ({bracket.rate}%)
                                 </span>
-                                <p className="text-sm text-gray-600 dark:text-gray-300">
+                                <p className="body text-gray-600 dark:text-gray-300">
                                   {bracket.bracketMin !== undefined
                                     ? `£${bracket.bracketMin.toLocaleString()} - `
                                     : ''}
@@ -1472,7 +1472,7 @@ export default function SalaryCalculatorUK() {
 
                         {/* National Insurance Breakdown */}
                         <div className="space-y-2">
-                          <Heading as="h4" size="h4" weight="medium" className="text-foreground">
+                          <Heading as="h4" size="h3" weight="medium" className="text-foreground">
                             {activeTab === 'netToGross'
                               ? showAdvanced && results.pension > 0
                                 ? '7'
@@ -1491,7 +1491,7 @@ export default function SalaryCalculatorUK() {
                                 <span className="font-medium text-gray-900 dark:text-gray-100">
                                   {bracket.rate}% Rate
                                 </span>
-                                <p className="text-sm text-gray-600 dark:text-gray-300">
+                                <p className="body text-gray-600 dark:text-gray-300">
                                   {bracket.min !== undefined
                                     ? `£${bracket.min.toLocaleString()} - `
                                     : ''}
@@ -1542,7 +1542,7 @@ export default function SalaryCalculatorUK() {
                                   .replace('postgraduate', 'Postgraduate')}
                                 )
                               </span>
-                              <p className="text-sm text-gray-600 dark:text-gray-300">
+                              <p className="body text-gray-600 dark:text-gray-300">
                                 {taxData[taxYear].studentLoanRates[studentLoanPlan]?.rate * 100}% on
                                 income above £
                                 {taxData[taxYear].studentLoanRates[
@@ -1567,7 +1567,7 @@ export default function SalaryCalculatorUK() {
                               <span className="font-medium text-gray-900 dark:text-gray-100">
                                 SEIS Tax Relief (50%)
                               </span>
-                              <p className="text-sm text-gray-600 dark:text-gray-300">
+                              <p className="body text-gray-600 dark:text-gray-300">
                                 On £{(Number(seisInvestment) || 0).toLocaleString('en-GB')}{' '}
                                 investment
                               </p>
@@ -1589,7 +1589,7 @@ export default function SalaryCalculatorUK() {
                               <span className="font-medium text-gray-900 dark:text-gray-100">
                                 EIS Tax Relief (30%)
                               </span>
-                              <p className="text-sm text-gray-600 dark:text-gray-300">
+                              <p className="body text-gray-600 dark:text-gray-300">
                                 On £{(Number(eisInvestment) || 0).toLocaleString('en-GB')}{' '}
                                 investment
                               </p>
@@ -1622,7 +1622,7 @@ export default function SalaryCalculatorUK() {
 
                         {activeTab === 'netToGross' && (
                           <div className="p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                            <p className="text-sm text-green-800 dark:text-green-300">
+                            <p className="body text-green-800 dark:text-green-300">
                               ✅ <strong>Perfect match!</strong> A gross salary of £
                               {results.grossAnnual?.toLocaleString('en-GB', {
                                 maximumFractionDigits: 0,
@@ -1638,7 +1638,7 @@ export default function SalaryCalculatorUK() {
 
                         <div className="grid md:grid-cols-4 gap-4 mt-6 pt-6 border-t dark:border-gray-700">
                           <div className="text-center p-4 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
-                            <p className="text-sm text-blue-800 dark:text-blue-300 font-medium">
+                            <p className="body text-blue-800 dark:text-blue-300 font-medium">
                               Monthly Take-Home
                             </p>
                             <p className="text-xl font-bold text-blue-900 dark:text-blue-100">
@@ -1650,7 +1650,7 @@ export default function SalaryCalculatorUK() {
                             </p>
                           </div>
                           <div className="text-center p-4 bg-purple-50 dark:bg-purple-900/30 rounded-lg">
-                            <p className="text-sm text-purple-800 dark:text-purple-300 font-medium">
+                            <p className="body text-purple-800 dark:text-purple-300 font-medium">
                               Weekly Take-Home
                             </p>
                             <p className="text-xl font-bold text-purple-900 dark:text-purple-100">
@@ -1662,7 +1662,7 @@ export default function SalaryCalculatorUK() {
                             </p>
                           </div>
                           <div className="text-center p-4 bg-green-50 dark:bg-green-900/30 rounded-lg">
-                            <p className="text-sm text-green-800 dark:text-green-300 font-medium">
+                            <p className="body text-green-800 dark:text-green-300 font-medium">
                               Daily Take-Home
                             </p>
                             <p className="text-xl font-bold text-green-900 dark:text-green-100">
@@ -1672,12 +1672,12 @@ export default function SalaryCalculatorUK() {
                                 maximumFractionDigits: 2,
                               })}
                             </p>
-                            <p className="text-xs text-green-600 dark:text-green-400">
+                            <p className="caption text-green-600 dark:text-green-400">
                               (5days/week)
                             </p>
                           </div>
                           <div className="text-center p-4 bg-indigo-50 dark:bg-indigo-900/30 rounded-lg">
-                            <p className="text-sm text-indigo-800 dark:text-indigo-300 font-medium">
+                            <p className="body text-indigo-800 dark:text-indigo-300 font-medium">
                               Hourly Take-Home
                             </p>
                             <p className="text-xl font-bold text-indigo-900 dark:text-indigo-100">
@@ -1687,7 +1687,7 @@ export default function SalaryCalculatorUK() {
                                 maximumFractionDigits: 2,
                               })}
                             </p>
-                            <p className="text-xs text-indigo-600 dark:text-indigo-400">
+                            <p className="caption text-indigo-600 dark:text-indigo-400">
                               (40hrs/week)
                             </p>
                           </div>
@@ -1707,7 +1707,7 @@ export default function SalaryCalculatorUK() {
                   <Card className="bg-amber-50 dark:bg-yellow-900/30 border-amber-200 dark:border-yellow-700">
                     <CardContent className="p-4 flex items-start gap-3">
                       <HelpCircle className="w-5 h-5 text-amber-700 dark:text-yellow-400 mt-0.5" />
-                      <p className="text-sm text-amber-800 dark:text-yellow-300">
+                      <p className="body text-amber-800 dark:text-yellow-300">
                         <strong>Disclaimer:</strong> This calculator provides estimates based on UK
                         tax rates for the selected tax year. Results are for guidance only and
                         should not be considered as professional financial advice. Actual deductions
@@ -1810,10 +1810,10 @@ export default function SalaryCalculatorUK() {
                 to={createPageUrl('SalaryCalculatorTakeHomePay')}
                 className="block rounded-lg border border-card-muted bg-card p-5 transition hover:border-primary/40 hover:shadow-md"
               >
-                <Heading as="h3" size="h4" className="text-card-foreground">
+                <Heading as="h3" size="h3" className="text-card-foreground">
                   Take-Home Pay Calculator
                 </Heading>
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="body text-muted-foreground mt-1">
                   Estimate your net pay after tax & NI.
                 </p>
               </Link>
@@ -1821,10 +1821,10 @@ export default function SalaryCalculatorUK() {
                 to={createPageUrl('SalaryCalculatorPaycheck')}
                 className="block rounded-lg border border-card-muted bg-card p-5 transition hover:border-primary/40 hover:shadow-md"
               >
-                <Heading as="h3" size="h4" className="text-card-foreground">
+                <Heading as="h3" size="h3" className="text-card-foreground">
                   Paycheck Calculator
                 </Heading>
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="body text-muted-foreground mt-1">
                   Weekly, fortnightly or monthly.
                 </p>
               </Link>
@@ -1832,10 +1832,10 @@ export default function SalaryCalculatorUK() {
                 to={createPageUrl('GrossToNetCalculator')}
                 className="block rounded-lg border border-card-muted bg-card p-5 transition hover:border-primary/40 hover:shadow-md"
               >
-                <Heading as="h3" size="h4" className="text-card-foreground">
+                <Heading as="h3" size="h3" className="text-card-foreground">
                   Gross to Net Calculator
                 </Heading>
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="body text-muted-foreground mt-1">
                   Convert gross salary to take-home.
                 </p>
               </Link>
@@ -1843,10 +1843,10 @@ export default function SalaryCalculatorUK() {
                 to={createPageUrl('ProRataSalaryCalculator')}
                 className="block rounded-lg border border-card-muted bg-card p-5 transition hover:border-primary/40 hover:shadow-md"
               >
-                <Heading as="h3" size="h4" className="text-card-foreground">
+                <Heading as="h3" size="h3" className="text-card-foreground">
                   Pro-Rata Salary Calculator
                 </Heading>
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="body text-muted-foreground mt-1">
                   Part-time & pro-rata earnings.
                 </p>
               </Link>
@@ -1858,7 +1858,7 @@ export default function SalaryCalculatorUK() {
         <div className="bg-neutral-soft py-12 non-printable">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <FAQSection faqs={salaryHubFaqs} title="Salary Calculator FAQs" />
-            <p className="text-xs text-muted-foreground mt-6">
+            <p className="caption text-muted-foreground mt-6">
               Last updated: <time dateTime={LAST_UPDATED_ISO}>{LAST_UPDATED_DISPLAY}</time>
             </p>
           </div>
@@ -1879,9 +1879,9 @@ export default function SalaryCalculatorUK() {
                 UK Salary Calculator - Everything You Need to Know
               </Heading>
             </div>
-            <div className="grid md:grid-cols-2 gap-8 text-sm text-muted-foreground">
+            <div className="grid md:grid-cols-2 gap-8 body text-muted-foreground">
               <div>
-                <Heading as="h3" size="h4" className="mb-3 text-foreground">
+                <Heading as="h3" size="h3" className="mb-3 text-foreground">
                   How Our UK Tax Calculator Works
                 </Heading>
                 <ul className="space-y-2">
@@ -1894,7 +1894,7 @@ export default function SalaryCalculatorUK() {
                 </ul>
               </div>
               <div>
-                <Heading as="h3" size="h4" className="mb-3 text-foreground">
+                <Heading as="h3" size="h3" className="mb-3 text-foreground">
                   Perfect for UK Employees &amp; Contractors
                 </Heading>
                 <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- upgrade the home hero, card copy, and directory listings to use the new title-hero, body, and caption typography tokens
- update the PAYE calculator hero paragraph, helper hints, and tables to the lead/body/caption scale
- refresh the Salary Calculator UK hero, breakdown cards, and supporting content to the latest heading and body token classes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e150ec1ab083209411e4d40530ad12