### PR TITLE
Allow API requests to bypass SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -39,7 +39,10 @@
     }
   ],
 
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/:path*" },
+    { "source": "/(.*)", "destination": "/" }
+  ],
 
   "cleanUrls": true,
   "trailingSlash": false


### PR DESCRIPTION
## Summary
- add a passthrough rewrite so `/api/:path*` requests bypass the single-page-app catch-all

## Testing
- npm install *(fails: Puppeteer cannot download Chromium because the environment blocks https protocol)*

------
https://chatgpt.com/codex/tasks/task_e_68e16dfa5de8832088a2bfdfa20a438f