### PR TITLE
Adjust Vercel rewrite to exclude API routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -41,7 +41,7 @@
 
   "rewrites": [
     { "source": "/api/:path*", "destination": "/api/:path*" },
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/((?!api/).*)", "destination": "/" }
   ],
 
   "cleanUrls": true,


### PR DESCRIPTION
## Summary
- update the Vercel catch-all rewrite to exclude paths under /api

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16f4989b88320bc4aa9b0794b10a3